### PR TITLE
bugfix: Properly display special characters in Organization name

### DIFF
--- a/packages/ui/components/core/Breadcrumb.stories.tsx
+++ b/packages/ui/components/core/Breadcrumb.stories.tsx
@@ -38,3 +38,10 @@ export const BackToDynamic = {
 		backToText: 'Sample Organization Name',
 	},
 } satisfies StoryDef
+export const BackToDynamicWithSpecialCharacters = {
+	args: {
+		option: 'back',
+		backTo: 'dynamicText',
+		backToText: "Sample Organization Name with special characters' % - *",
+	},
+} satisfies StoryDef

--- a/packages/ui/components/core/Breadcrumb.tsx
+++ b/packages/ui/components/core/Breadcrumb.tsx
@@ -4,6 +4,8 @@ import { MouseEventHandler } from 'react'
 
 import { Icon } from '~ui/icon'
 
+import { PageLoadProgress } from './PageLoadProgress'
+
 const useStyles = createStyles((theme) => ({
 	root: {
 		// height: '40px',
@@ -50,7 +52,7 @@ export const Breadcrumb = (props: BreadcrumbProps) => {
 					case 'dynamicText': {
 						const page = props.backToText
 						return (
-							<Trans i18nKey='back-to-dynamic' ns='common' values={{ page }}>
+							<Trans i18nKey='back-to-dynamic' ns='common' values={{ page }} shouldUnescape={true}>
 								Back to <span style={{ textDecoration: 'underline' }}>{page}</span>
 							</Trans>
 						)

--- a/packages/ui/components/core/Breadcrumb.tsx
+++ b/packages/ui/components/core/Breadcrumb.tsx
@@ -4,8 +4,6 @@ import { MouseEventHandler } from 'react'
 
 import { Icon } from '~ui/icon'
 
-import { PageLoadProgress } from './PageLoadProgress'
-
 const useStyles = createStyles((theme) => ({
 	root: {
 		// height: '40px',


### PR DESCRIPTION
leverage the shouldUnescape={true} component from Trans 'next-i18next' library so variables, within the translated text, that also contain special characters, will be displayed correctly.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
https://inreach.atlassian.net/browse/IN-798

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
