### PR TITLE
fix(app): Current services still filtered when changing pages

### DIFF
--- a/apps/app/src/pages/search/[...params]/index.tsx
+++ b/apps/app/src/pages/search/[...params]/index.tsx
@@ -255,7 +255,11 @@ const SearchResults = () => {
 						/>
 					</Group>
 					<Group noWrap w={{ base: '100%', md: '50%' }}>
-						<ServiceFilter resultCount={resultCount} isFetching={searchIsFetching} />
+						<ServiceFilter
+							resultCount={resultCount}
+							isFetching={searchIsFetching}
+							current={searchState.services}
+						/>
 						{/* @ts-expect-error `component` prop not needed.. */}
 						<MoreFilter resultCount={resultCount} isFetching={searchIsFetching}>
 							{t('more.filters')}

--- a/packages/ui/modals/ServiceFilter/index.tsx
+++ b/packages/ui/modals/ServiceFilter/index.tsx
@@ -29,7 +29,7 @@ import { trpc as api } from '~ui/lib/trpcClient'
 
 import { useAccordionStyles, useModalStyles, useStyles } from './styles'
 
-export const ServiceFilter = ({ resultCount, isFetching, disabled }: ServiceFilterProps) => {
+export const ServiceFilter = ({ resultCount, isFetching, current, disabled }: ServiceFilterProps) => {
 	const { data: serviceOptionData } = api.service.getFilterOptions.useQuery(undefined, {
 		select: (data) =>
 			data.map(({ id, tsKey, tsNs, services }) => ({
@@ -63,8 +63,9 @@ export const ServiceFilter = ({ resultCount, isFetching, disabled }: ServiceFilt
 		: typeof router.query.s === 'string'
 			? [router.query.s]
 			: []
+
 	const form = useForm<{ selected: string[] }>({
-		values: { selected: preSelected },
+		values: { selected: current ? current : preSelected },
 	})
 	const servicesByCategory = useMemo(
 		() =>
@@ -305,5 +306,6 @@ export const ServiceFilter = ({ resultCount, isFetching, disabled }: ServiceFilt
 interface ServiceFilterProps {
 	resultCount?: number
 	isFetching?: boolean
+	current?: string[]
 	disabled?: boolean
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when switching pages the filters are removed

Issue Number: https://inreach.atlassian.net/browse/IN-946

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The current filters are passed through now to persist them

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

- There is a little flickering, not sure if that is new
- There is some unused logic to make this work that could be because the component is reused by another source. This should be carefully regression tested to make sure other use cases still work. The goal of this PR is to leave that logic still intact.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
