### PR TITLE
fix: page error handling

### DIFF
--- a/apps/app/src/pages/index.tsx
+++ b/apps/app/src/pages/index.tsx
@@ -352,11 +352,9 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
 		ssg.review.getFeatured.prefetch(3),
 	])
 
-	// await ssg.review.getFeatured.prefetch(3)
 	return {
 		props: {
 			trpcState: ssg.dehydrate(),
-			// ...(await getServerSideTranslations(locale, ['common', 'landingPage', 'attribute'])),
 			...(i18n.status === 'fulfilled' ? i18n.value : {}),
 		},
 		revalidate: 60 * 60 * 24, // 24 hours

--- a/apps/app/src/pages/org/[slug]/[orgLocationId]/edit.tsx
+++ b/apps/app/src/pages/org/[slug]/[orgLocationId]/edit.tsx
@@ -4,7 +4,7 @@ import { type InferGetServerSidePropsType, type NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { type GetServerSidePropsContext } from 'nextjs-routes'
+import { type GetServerSideProps } from 'nextjs-routes'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -239,12 +239,10 @@ const OrgLocationPage: NextPage<InferGetServerSidePropsType<typeof getServerSide
 	)
 }
 
-export const getServerSideProps = async ({
-	locale,
-	params,
-	req,
-	res,
-}: GetServerSidePropsContext<'/org/[slug]/[orgLocationId]/edit'>) => {
+export const getServerSideProps: GetServerSideProps<
+	{ organizationId: string } & Record<string, unknown>,
+	'/org/[slug]/[orgLocationId]/edit'
+> = async ({ locale, params, req, res }) => {
 	const urlParams = z.object({ slug: z.string(), orgLocationId: prefixedId('orgLocation') }).safeParse(params)
 	if (!urlParams.success) {
 		return { notFound: true }

--- a/apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx
+++ b/apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx
@@ -1,7 +1,7 @@
 import { createStyles, Divider, Grid, Stack, Tabs, useMantineTheme } from '@mantine/core'
 import { useMediaQuery } from '@mantine/hooks'
 // import compact from 'just-compact'
-import { type GetStaticPaths, type GetStaticPropsContext, type NextPage } from 'next'
+import { type GetStaticPaths, type GetStaticProps, type NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
@@ -178,10 +178,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 		fallback: true,
 	}
 }
-export const getStaticProps = async ({
-	locale,
-	params,
-}: GetStaticPropsContext<RoutedQuery<'/org/[slug]/[orgLocationId]'>>) => {
+export const getStaticProps: GetStaticProps<
+	Record<string, unknown>,
+	RoutedQuery<'/org/[slug]/[orgLocationId]'>
+> = async ({ locale, params }) => {
 	const urlParams = z.object({ slug: z.string(), orgLocationId: z.string() }).safeParse(params)
 	if (!urlParams.success) {
 		return { notFound: true }
@@ -213,7 +213,6 @@ export const getStaticProps = async ({
 		])
 		const props = {
 			trpcState: ssg.dehydrate(),
-			// ...(await getServerSideTranslations(locale, ['common', 'services', 'attribute', 'phone-type', slug])),
 			...(i18n.status === 'fulfilled' ? i18n.value : {}),
 		}
 
@@ -226,7 +225,7 @@ export const getStaticProps = async ({
 		if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
 			return { notFound: true }
 		}
-		return { props: {}, revalidate: 1 }
+		return { redirect: { destination: '/500', permanent: false } }
 	}
 }
 type Tabname = 'services' | 'photos' | 'reviews'

--- a/apps/app/src/pages/org/[slug]/edit.tsx
+++ b/apps/app/src/pages/org/[slug]/edit.tsx
@@ -2,10 +2,10 @@ import { Grid, Stack } from '@mantine/core'
 import { useElementSize } from '@mantine/hooks'
 import { t } from 'i18next'
 import compact from 'just-compact'
-import { type GetServerSidePropsContext, type InferGetServerSidePropsType } from 'next'
+import { type InferGetServerSidePropsType } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { type RoutedQuery } from 'nextjs-routes'
+import { type GetServerSideProps } from 'nextjs-routes'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -136,12 +136,12 @@ const OrganizationPage: NextPageWithOptions<InferGetServerSidePropsType<typeof g
 	)
 }
 
-export const getServerSideProps = async ({
+export const getServerSideProps: GetServerSideProps<{ organizationId: string }, '/org/[slug]'> = async ({
 	locale,
 	params,
 	req,
 	res,
-}: GetServerSidePropsContext<RoutedQuery<'/org/[slug]'>>) => {
+}) => {
 	if (!params) {
 		return { notFound: true }
 	}

--- a/apps/app/src/pages/org/[slug]/index.tsx
+++ b/apps/app/src/pages/org/[slug]/index.tsx
@@ -1,6 +1,6 @@
 import { createStyles, Divider, Grid, Stack, Tabs, useMantineTheme } from '@mantine/core'
 import { useElementSize, useMediaQuery } from '@mantine/hooks'
-import { type GetStaticPaths, type GetStaticPropsContext, type InferGetStaticPropsType } from 'next'
+import { type GetStaticPaths, type GetStaticProps, type InferGetStaticPropsType } from 'next'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
@@ -245,10 +245,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 	// }
 }
 
-export const getStaticProps = async ({
-	locale,
-	params,
-}: GetStaticPropsContext<RoutedQuery<'/org/[slug]'>>) => {
+export const getStaticProps: GetStaticProps<
+	{ slug: string; organizationId: string },
+	RoutedQuery<'/org/[slug]'>
+> = async ({ locale, params }) => {
 	if (!params) {
 		return { notFound: true }
 	}
@@ -290,6 +290,8 @@ export const getStaticProps = async ({
 		const TRPCError = (await import('@trpc/server')).TRPCError
 		if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
 			return { notFound: true }
+		} else {
+			return { redirect: { destination: '/500', permanent: false } }
 		}
 	}
 }

--- a/apps/app/src/pages/search/intl/[country].tsx
+++ b/apps/app/src/pages/search/intl/[country].tsx
@@ -12,7 +12,7 @@ import {
 	useMantineTheme,
 } from '@mantine/core'
 import { useMediaQuery } from '@mantine/hooks'
-import { type GetStaticPaths, type GetStaticPropsContext } from 'next'
+import { type GetStaticPaths, type GetStaticProps } from 'next'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
@@ -152,10 +152,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 		fallback: 'blocking',
 	}
 }
-export const getStaticProps = async ({
-	params,
-	locale,
-}: GetStaticPropsContext<RoutedQuery<'/search/intl/[country]'>>) => {
+export const getStaticProps: GetStaticProps<
+	Record<string, unknown>,
+	RoutedQuery<'/search/intl/[country]'>
+> = async ({ params, locale }) => {
 	const parsedQuery = QuerySchema.safeParse(params)
 	if (!parsedQuery.success) {
 		return {

--- a/apps/app/src/pages/suggest.tsx
+++ b/apps/app/src/pages/suggest.tsx
@@ -1,5 +1,5 @@
 import { Grid, Overlay } from '@mantine/core'
-import { type GetStaticPropsContext } from 'next'
+import { type GetStaticProps } from 'next'
 import dynamic from 'next/dynamic'
 import { useSession } from 'next-auth/react'
 import { useCallback, useState } from 'react'
@@ -7,7 +7,6 @@ import { useCallback, useState } from 'react'
 import { trpcServerClient } from '@weareinreach/api/trpc'
 import { SuggestOrg } from '@weareinreach/ui/components/sections/SuggestOrg'
 import { getServerSideTranslations } from '~app/utils/i18n'
-// import { QuickPromotionModal } from '@weareinreach/ui/modals'
 
 // @ts-expect-error Next Dynamic doesn't like polymorphic components
 const QuickPromotionModal = dynamic(() =>
@@ -37,7 +36,7 @@ const SuggestResource = () => {
 
 export default SuggestResource
 
-export const getStaticProps = async ({ locale }: GetStaticPropsContext) => {
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
 	const ssg = await trpcServerClient({ session: null })
 
 	const [i18n] = await Promise.allSettled([

--- a/packages/api/lib/errorHandler.ts
+++ b/packages/api/lib/errorHandler.ts
@@ -1,8 +1,8 @@
 import { TRPCError } from '@trpc/server'
-// import { Logger } from 'tslog'
 import { ZodError } from 'zod'
 
 import { Prisma } from '@weareinreach/db'
+import { createLoggerInstance } from '@weareinreach/util/logger'
 
 import { PRISMA_ERROR_CODES } from './prismaErrorCodes'
 
@@ -12,17 +12,11 @@ const mapEntries = Object.entries(PRISMA_ERROR_CODES).map(([key, value]) => [key
 ][]
 const prismaErrorMap = new Map<string, TRPCError['code']>(mapEntries)
 
-// const devLog = (error: unknown) => {
-// 	// eslint-disable-next-line node/no-process-env
-// 	if (process.env.NODE_ENV !== 'production') {
-// 		const logger = new Logger()
-
-// 		logger.error(error)
-// 	}
-// }
+const logger = createLoggerInstance('tRPC Error Handler')
 
 export const handleError = (error: unknown) => {
-	// devLog(error)
+	logger.error(error)
+
 	// pass through if already TRPCError
 	if (error instanceof TRPCError) {
 		throw error
@@ -44,7 +38,9 @@ export const handleError = (error: unknown) => {
 	if (error instanceof Error) {
 		throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: error.message, cause: error.cause })
 	} else {
-		if (typeof error === 'object') error = JSON.stringify(error)
+		if (typeof error === 'object') {
+			error = JSON.stringify(error)
+		}
 		throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: `${error}` })
 	}
 }

--- a/packages/api/router/organization/query.forOrgPage.handler.ts
+++ b/packages/api/router/organization/query.forOrgPage.handler.ts
@@ -1,51 +1,56 @@
 import { prisma } from '@weareinreach/db'
+import { handleError } from '~api/lib/errorHandler'
 import { attributes, freeText, isPublic } from '~api/schemas/selects/common'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TForOrgPageSchema } from './query.forOrgPage.schema'
 
 const forOrgPage = async ({ input }: TRPCHandlerParams<TForOrgPageSchema>) => {
-	const { slug } = input
-	const org = await prisma.organization.findUniqueOrThrow({
-		where: {
-			slug,
-			...isPublic,
-		},
-		select: {
-			id: true,
-			name: true,
-			slug: true,
-			published: true,
-			lastVerified: true,
-			allowedEditors: { where: { authorized: true }, select: { userId: true } },
-			description: freeText,
-
-			reviews: {
-				where: { visible: true, deleted: false },
-				select: { id: true },
+	try {
+		const { slug } = input
+		const org = await prisma.organization.findUniqueOrThrow({
+			where: {
+				slug,
+				...isPublic,
 			},
-			locations: {
-				where: isPublic,
-				select: {
-					id: true,
-					street1: true,
-					street2: true,
-					city: true,
-					postCode: true,
-					country: { select: { cca2: true } },
-					govDist: { select: { abbrev: true, tsKey: true, tsNs: true } },
-					notVisitable: true,
+			select: {
+				id: true,
+				name: true,
+				slug: true,
+				published: true,
+				lastVerified: true,
+				allowedEditors: { where: { authorized: true }, select: { userId: true } },
+				description: freeText,
+
+				reviews: {
+					where: { visible: true, deleted: false },
+					select: { id: true },
 				},
+				locations: {
+					where: isPublic,
+					select: {
+						id: true,
+						street1: true,
+						street2: true,
+						city: true,
+						postCode: true,
+						country: { select: { cca2: true } },
+						govDist: { select: { abbrev: true, tsKey: true, tsNs: true } },
+						notVisitable: true,
+					},
+				},
+				attributes,
 			},
-			attributes,
-		},
-	})
-	const { allowedEditors, ...orgData } = org
-	const reformatted = {
-		...orgData,
-		isClaimed: Boolean(allowedEditors.length),
-	}
+		})
+		const { allowedEditors, ...orgData } = org
+		const reformatted = {
+			...orgData,
+			isClaimed: Boolean(allowedEditors.length),
+		}
 
-	return reformatted
+		return reformatted
+	} catch (err) {
+		return handleError(err)
+	}
 }
 export default forOrgPage

--- a/packages/api/router/organization/query.getIdFromSlug.handler.ts
+++ b/packages/api/router/organization/query.getIdFromSlug.handler.ts
@@ -1,31 +1,36 @@
 import { checkPermissions } from '@weareinreach/auth'
 import { prisma } from '@weareinreach/db'
 import { readSlugCache, writeSlugCache } from '~api/cache/slugToOrgId'
+import { handleError } from '~api/lib/errorHandler'
 import { isPublic } from '~api/schemas/selects/common'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TGetIdFromSlugSchema } from './query.getIdFromSlug.schema'
 
 const getIdFromSlug = async ({ ctx, input }: TRPCHandlerParams<TGetIdFromSlugSchema>) => {
-	const { slug } = input
-	const cachedId = await readSlugCache(slug)
-	if (cachedId) {
-		return { id: cachedId }
-	}
-	const canSeeUnpublished =
-		ctx.session !== null &&
-		checkPermissions({
-			session: ctx.session,
-			permissions: ['dataPortalBasic', 'dataPortalAdmin', 'dataPortalManager'],
-			has: 'some',
+	try {
+		const { slug } = input
+		const cachedId = await readSlugCache(slug)
+		if (cachedId) {
+			return { id: cachedId }
+		}
+		const canSeeUnpublished =
+			ctx.session !== null &&
+			checkPermissions({
+				session: ctx.session,
+				permissions: ['dataPortalBasic', 'dataPortalAdmin', 'dataPortalManager'],
+				has: 'some',
+			})
+		const orgId = await prisma.organization.findUniqueOrThrow({
+			where: { slug, ...(canSeeUnpublished ? {} : isPublic) },
+			select: { id: true, published: true, deleted: true },
 		})
-	const orgId = await prisma.organization.findUniqueOrThrow({
-		where: { slug, ...(canSeeUnpublished ? {} : isPublic) },
-		select: { id: true, published: true, deleted: true },
-	})
-	if (orgId.published && !orgId.deleted) {
-		await writeSlugCache(slug, orgId.id)
+		if (orgId.published && !orgId.deleted) {
+			await writeSlugCache(slug, orgId.id)
+		}
+		return { id: orgId.id }
+	} catch (err) {
+		return handleError(err)
 	}
-	return { id: orgId.id }
 }
 export default getIdFromSlug

--- a/packages/api/router/organization/query.slugRedirect.handler.ts
+++ b/packages/api/router/organization/query.slugRedirect.handler.ts
@@ -1,24 +1,29 @@
 import { prisma } from '@weareinreach/db'
 import { readSlugRedirectCache, writeSlugRedirectCache } from '~api/cache/slugRedirect'
+import { handleError } from '~api/lib/errorHandler'
 import { isPublic } from '~api/schemas/selects/common'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TSlugRedirectSchema } from './query.slugRedirect.schema'
 
 const slugRedirect = async ({ input }: TRPCHandlerParams<TSlugRedirectSchema>) => {
-	const cached = await readSlugRedirectCache(input)
-	if (cached) {
-		return { redirectTo: cached }
+	try {
+		const cached = await readSlugRedirectCache(input)
+		if (cached) {
+			return { redirectTo: cached }
+		}
+		const { slug: primarySlug } =
+			(await prisma.organization.findFirst({
+				where: { OR: [{ slug: input }, { oldSlugs: { some: { from: input } } }], ...isPublic },
+				select: { slug: true },
+			})) ?? {}
+		if (primarySlug && primarySlug !== input) {
+			await writeSlugRedirectCache(input, primarySlug)
+			return { redirectTo: primarySlug }
+		}
+		return { redirectTo: null }
+	} catch (err) {
+		return handleError(err)
 	}
-	const { slug: primarySlug } =
-		(await prisma.organization.findFirst({
-			where: { OR: [{ slug: input }, { oldSlugs: { some: { from: input } } }], ...isPublic },
-			select: { slug: true },
-		})) ?? {}
-	if (primarySlug && primarySlug !== input) {
-		await writeSlugRedirectCache(input, primarySlug)
-		return { redirectTo: primarySlug }
-	}
-	return { redirectTo: null }
 }
 export default slugRedirect

--- a/packages/ui/components/data-portal/MultiSelectPopover/hook-form.tsx
+++ b/packages/ui/components/data-portal/MultiSelectPopover/hook-form.tsx
@@ -1,18 +1,6 @@
-import {
-	type CheckboxGroupProps as $CheckboxGroupProps,
-	Checkbox,
-	createStyles,
-	Group,
-	LoadingOverlay,
-	Popover,
-	rem,
-	ScrollArea,
-	Text,
-	UnstyledButton,
-} from '@mantine/core'
-import { useDisclosure, useListState } from '@mantine/hooks'
-import compare from 'just-compare'
-import { type CSSProperties, useCallback, useEffect, useMemo } from 'react'
+import { Checkbox, Group, LoadingOverlay, Popover, ScrollArea, Text, UnstyledButton } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { type CSSProperties, useCallback } from 'react'
 import { type FieldValues, useController, type UseControllerProps, useWatch } from 'react-hook-form'
 
 import { Icon } from '~ui/icon'
@@ -32,7 +20,7 @@ export const MultiSelectPopover = <T extends FieldValues>({
 	labelClassName,
 	fullWidth,
 	indicateWhenDirty,
-	...props
+	disabled,
 }: MultiSelectPopoverProps<T>) => {
 	const {
 		field: { value, onChange: fieldOnChange, ...field },
@@ -43,6 +31,7 @@ export const MultiSelectPopover = <T extends FieldValues>({
 		defaultValue,
 		rules,
 		shouldUnregister,
+		disabled,
 	})
 	const selectedItems = useWatch({ name, control })
 	const selected = selectedItems?.length ?? 0
@@ -52,60 +41,55 @@ export const MultiSelectPopover = <T extends FieldValues>({
 
 	const selectedCountIcon = <Text className={classes.count}>{selected}</Text>
 
+	const handleCheckboxGroupChange: (e: string[]) => void = useCallback(
+		(e) => {
+			fieldOnChange(e)
+			onChange?.(e)
+		},
+		[fieldOnChange, onChange]
+	)
+
 	return (
-		<>
-			<Popover
-				opened={opened}
-				onClose={() => {
-					menuHandler.close()
-				}}
-				trapFocus
-				withinPortal
-			>
-				<LoadingOverlay visible={data === undefined} />
-				<Popover.Target>
-					<UnstyledButton
-						onClick={menuHandler.toggle}
-						className={cx({ [classes.button]: true, [classes.indicateDirty]: indicateWhenDirty })}
-						style={style}
-						w={fullWidth ? '100%' : undefined}
-						data-isDirty={fieldState.isDirty}
-					>
-						<Group noWrap position='apart' spacing={16}>
-							<Group noWrap spacing={8}>
-								{selectedCountIcon}
-								<Text style={{ display: 'inline-block' }} className={labelClassName}>
-									{label}
-								</Text>
-							</Group>
-							<Icon icon={opened ? 'carbon:chevron-up' : 'carbon:chevron-down'} height={24} />
+		<Popover opened={opened} onClose={menuHandler.close} trapFocus withinPortal>
+			<LoadingOverlay visible={data === undefined} />
+			<Popover.Target>
+				<UnstyledButton
+					onClick={menuHandler.toggle}
+					className={cx({ [classes.button]: true, [classes.indicateDirty]: indicateWhenDirty })}
+					style={style}
+					w={fullWidth ? '100%' : undefined}
+					data-isDirty={fieldState.isDirty}
+				>
+					<Group noWrap position='apart' spacing={16}>
+						<Group noWrap spacing={8}>
+							{selectedCountIcon}
+							<Text style={{ display: 'inline-block' }} className={labelClassName}>
+								{label}
+							</Text>
 						</Group>
-					</UnstyledButton>
-				</Popover.Target>
-				<Popover.Dropdown>
-					<ScrollArea.Autosize
-						mah={250}
-						placeholder={null}
-						// TODO: Typescript wants these two properties all of a sudden -- why?
-						onPointerEnterCapture={undefined}
-						onPointerLeaveCapture={undefined}
+						<Icon icon={opened ? 'carbon:chevron-up' : 'carbon:chevron-down'} height={24} />
+					</Group>
+				</UnstyledButton>
+			</Popover.Target>
+			<Popover.Dropdown>
+				<ScrollArea.Autosize
+					mah={250}
+					placeholder={null}
+					onPointerEnterCapture={undefined}
+					onPointerLeaveCapture={undefined}
+				>
+					<Checkbox.Group
+						error={fieldState.error?.message}
+						value={value}
+						label={label}
+						onChange={handleCheckboxGroupChange}
+						{...field}
 					>
-						<Checkbox.Group
-							error={fieldState.error?.message}
-							value={value}
-							label={label}
-							onChange={(e) => {
-								fieldOnChange(e)
-								onChange?.(e)
-							}}
-							{...field}
-						>
-							{data?.map((props, index) => <Checkbox key={props.value} {...props} />)}
-						</Checkbox.Group>
-					</ScrollArea.Autosize>
-				</Popover.Dropdown>
-			</Popover>
-		</>
+						{data?.map((checkboxProps) => <Checkbox key={checkboxProps.value} {...checkboxProps} />)}
+					</Checkbox.Group>
+				</ScrollArea.Autosize>
+			</Popover.Dropdown>
+		</Popover>
 	)
 }
 //)
@@ -117,7 +101,6 @@ export interface MultiSelectPopoverProps<T extends FieldValues> extends UseContr
 		[k: string]: string
 	}[]
 	label: string
-	value?: string[]
 	onChange?: (value: string[]) => void
 	style?: CSSProperties
 	labelClassName?: string


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: IN-968

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

### Walkthrough

The recent updates focus on refining error handling, updating import statements, and enhancing function signatures across various files in both the app and API layers. Key changes include the introduction of a new logging system, adjustments to data fetching methods, and more precise type declarations. These modifications aim to improve code clarity, maintainability, and performance.

### Changes

| File Path                                           | Change Summary                                                                                      |
|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------|
| `apps/app/src/pages/.../index.tsx`                  | Updated `getStaticProps` to include i18n values and removed commented code.                         |
| `apps/app/src/pages/.../[orgLocationId]/edit.tsx`   | Changed imports and function signature in `getServerSideProps`.                                     |
| `apps/app/src/pages/.../[orgLocationId]/index.tsx`  | Switched to `GetStaticProps` and updated return to include redirect.                                |
| `apps/app/src/pages/org/[slug]/edit.tsx`            | Updated imports and function signature in `getServerSideProps`.                                     |
| `apps/app/src/pages/search/intl/[country].tsx`      | Updated type declarations for `GetStaticProps`.                                                     |
| `apps/app/src/pages/suggest.tsx`                    | Changed import to `GetStaticProps` and updated function signature.                                  |
| `packages/api/lib/errorHandler.ts`                  | Refactored logging and incorporated a new logger instance.                                          |
| `packages/api/router/organization/...`              | Enhanced error handling with `handleError` and updated data retrieval logic in various handlers.    |
| `packages/ui/components/data-portal/.../hook-form.tsx` | Refactored imports, props, and handlers for the `MultiSelectPopover` component.                    |


<!-- walkthrough_end --><!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!--


apps/app/src/pages/index.tsx: ## Short Summary

In the `index.tsx` file:
- Modified `getStaticProps` to remove a commented-out line and adjust the returned object to include i18n values based on a condition.

## Alterations to the declarations of exported or public entities

- `export const getStaticProps: GetStaticProps = async ({ locale })`:
  - Removed the commented-out line `// await ssg.review.getFeatured.prefetch(3)`
  - Modified the returned object to include i18n values based on a condition

---

apps/app/src/pages/org/[slug]/[orgLocationId]/edit.tsx: ## Short Summary
In the `edit.tsx` file within the `org/[slug]/[orgLocationId]` directory:
- Updated the import statement to use `type GetServerSideProps` instead of `type GetServerSidePropsContext`.
- Modified the `getServerSideProps` function signature to include specific types for parameters and return values.

## Alterations to the declarations of exported or public entities
- `import { type GetServerSideProps } from 'nextjs-routes'` in `edit.tsx`
- `export const getServerSideProps: GetServerSideProps<{ organizationId: string } & Record<string, unknown>, '/org/[slug]/[orgLocationId]/edit'> = async ({ locale, params, req, res }) => {`

---

apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx: ### Summary

In `apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx`:
- Changed `GetStaticPropsContext` to `GetStaticProps`.
- Updated the return value in `getStaticProps` to include a redirect object instead of an empty props object.

---

apps/app/src/pages/org/[slug]/edit.tsx: ### Summary

In the `edit.tsx` file located at `apps/app/src/pages/org/[slug]/edit.tsx`:
- Removed `type GetServerSidePropsContext` import from 'next'.
- Changed `type RoutedQuery` import to `type GetServerSideProps` from 'nextjs-routes'.
- Updated the signature of `getServerSideProps` function.

---

apps/app/src/pages/search/intl/[country].tsx: ## Short Summary
In `apps/app/src/pages/search/intl/[country].tsx`:
- Updated the type declarations for `GetStaticProps` in the `next` module.
- Modified the function signature to include specific types for parameters.

## Alterations to the declarations of exported or public entities
- `type GetStaticProps` in `next` module in `apps/app/src/pages/search/intl/[country].tsx`

---

apps/app/src/pages/suggest.tsx: ## Short Summary
In the file `suggest.tsx`:
- Updated the import statement to use `type GetStaticProps` instead of `type GetStaticPropsContext`.
- Modified the function signature for `getStaticProps` to align with this change.

## Alterations to the declarations of exported or public entities
- `import { type GetStaticProps } from 'next'`
- `export const getStaticProps: GetStaticProps = async ({ locale }) => {`

---

packages/api/lib/errorHandler.ts: ## Short Summary

In `errorHandler.ts`:
- Refactored the logging mechanism by introducing a new logger instance and removing the previous logging setup.
- The error handling function now uses the new logger for error logging.

---

packages/api/router/organization/query.forOrgPage.handler.ts: ### Summary

In `query.forOrgPage.handler.ts`:
- Restructured the `forOrgPage` function to include error handling using `handleError`.
- Adjusted the structure of the `org` object retrieval within a `try-catch` block.

### Alterations to the declarations of exported or public entities

- `import { handleError } from '~api/lib/errorHandler'` added
- Adjusted the structure of the `forOrgPage` function to include error handling within a `try-catch` block
- Modified the selection of properties for the `org` object retrieval within the `findUniqueOrThrow` method

---

packages/api/router/organization/query.getIdFromSlug.handler.ts: ## Short Summary
In `query.getIdFromSlug.handler.ts`:
- Updated the `getIdFromSlug` function to include error handling using `handleError`.
- Improved the logic for fetching `orgId` to handle errors effectively.

## Alterations to the declarations of exported or public entities
- `import { handleError } from '~api/lib/errorHandler'` added
- Exception handling block added within `getIdFromSlug` function to catch errors and return the result using `handleError`

---

packages/api/router/organization/query.slugRedirect.handler.ts: ## Short Summary

In `query.slugRedirect.handler.ts`:
- Updated the `slugRedirect` function to handle caching and redirection based on slug values.
- Improved error handling by introducing a call to `handleError` in case of exceptions.

## Alterations to the declarations of exported or public entities

- `import { handleError } from '~api/lib/errorHandler'` added
- Exception handling with `try-catch` block added to `slugRedirect` function
- Logic for caching and redirection based on slug values updated within the `slugRedirect` function

---

packages/ui/components/data-portal/MultiSelectPopover/hook-form.tsx: ### Summary:
In the `hook-form.tsx` file for `MultiSelectPopover` component:
- Refactored imports, removed unused imports, adjusted props destructuring, handled disabled state, and updated the checkbox group change handler.

### Alterations to the declarations of exported or public entities:
- Removed unused imports and adjusted import statements.
- Updated props destructuring to include `disabled` property.
- Refactored the checkbox group change handler to a useCallback hook.

-->
<!-- end of auto-generated comment: raw summary by coderabbit.ai --><!-- This is an auto-generated comment: short summary by coderabbit.ai -->
<!--


### PR Objectives (User Provided Facts)

The pull request titled "fix: page error handling" (PR #1255) aims to address a bug identified in issue IN-968. The changes are confined to bug fixes, as indicated by the checked "Bugfix" option under the type of change. The PR does not introduce any breaking changes, ensuring compatibility with existing applications. The description and the checklist provided in the PR suggest a focus on enhancing error handling mechanisms across various components and pages within the application. The modifications span multiple files, primarily involving updates to error handling functions, adjustments in type declarations, and refinements in function signatures to improve the robustness and clarity of the codebase.

### AI-Generated Summary of Generated Summaries

This pull request introduces a series of updates aimed at refining error handling and type declarations across multiple components and pages within the application. The changes are detailed as follows:

1. **Page-Level Updates:**
   - In `index.tsx`, `getStaticProps` was modified to enhance i18n support based on conditions, removing outdated commented code.
   - The `edit.tsx` files in both the `org/[slug]/[orgLocationId]` and `org/[slug]` directories saw updates in their import statements to use more specific types, and adjustments in `getServerSideProps` to include detailed types for parameters and return values.
   - The `index.tsx` file within `org/[slug]/[orgLocationId]` now includes a redirect object in `getStaticProps` instead of returning an empty props object, enhancing the page's response to certain states.
   - The `suggest.tsx` and `search/intl/[country].tsx` pages had their `getStaticProps` function signatures updated to align with the new type declarations, improving clarity and type safety.

2. **API and Error Handling Enhancements:**
   - The `errorHandler.ts` file now utilizes a new logger instance for error logging, replacing the previous setup and streamlining the logging process.
   - Several API handlers (`query.forOrgPage.handler.ts`, `query.getIdFromSlug.handler.ts`, and `query.slugRedirect.handler.ts`) incorporated improved error handling using the `handleError` function. These updates include better structure in error catching and enhancements in logic for fetching and redirecting based on slug values.

3. **Component-Level Refinements:**
   - The `MultiSelectPopover` component in `hook-form.tsx` saw a refactor in its imports and props destructuring. The checkbox group change handler was updated to use a `useCallback` hook, optimizing performance and readability.

These updates collectively aim to enhance the application's robustness through better error handling, clearer type usage, and more precise function implementations.

### Alterations to the Declarations of Exported or Public Entities

- **index.tsx**:
  - Before: `export const getStaticProps: GetStaticProps = async ({ locale })`
  - After: `export const getStaticProps: GetStaticProps = async ({ locale })` (Enhanced to include i18n values conditionally)

- **edit.tsx (org/[slug]/[orgLocationId] and org/[slug])**:
  - Before: `import { type GetServerSidePropsContext } from 'next'`
  - After: `import { type GetServerSideProps } from 'nextjs-routes'`
  - Before: `export const getServerSideProps: GetServerSidePropsContext = async ({ params }) => {}`
  - After: `export const getServerSideProps: GetServerSideProps<{ organizationId: string } & Record<string, unknown>, '/org/[slug]/[orgLocationId]/edit'> = async ({ locale, params, req, res }) => {}`

- **suggest.tsx** and **search/intl/[country].tsx**:
  - Before: `import { type GetStaticPropsContext } from 'next'`
  - After: `import { type GetStaticProps } from 'next'`
  - Before: `export const getStaticProps: GetStaticPropsContext = async ({ locale }) => {}`
  - After: `export const getStaticProps: GetStaticProps = async ({ locale }) => {}`

- **errorHandler.ts** and API handlers (`query.forOrgPage.handler.ts`, `query.getIdFromSlug.handler.ts`, `query.slugRedirect.handler.ts`):
  - New Import: `import { handleError } from '~api/lib/errorHandler'`
  - Enhanced error handling structures within function implementations.

- **MultiSelectPopover/hook-form.tsx**:
  - Before: Various unused imports and basic props destructuring.
  - After: Streamlined imports and updated props destructuring to include `disabled` property. Refactored checkbox group change handler to use `useCallback`.

-->
<!-- end of auto-generated comment: short summary by coderabbit.ai -->
