### PR TITLE
fix: link email to org on creation

### DIFF
--- a/packages/api/router/orgEmail/mutation.update.handler.ts
+++ b/packages/api/router/orgEmail/mutation.update.handler.ts
@@ -51,9 +51,15 @@ const update = async ({ ctx, input }: TRPCHandlerParams<TUpdateSchema, 'protecte
 						email,
 						...record,
 						description: updateDescriptionText ? { create: updateDescriptionText.upsert.create } : undefined,
-						...(linkLocationId && {
-							locations: { createMany: { data: [{ orgLocationId: linkLocationId }], skipDuplicates: true } },
-						}),
+						...(linkLocationId
+							? {
+									locations: {
+										createMany: { data: [{ orgLocationId: linkLocationId }], skipDuplicates: true },
+									},
+								}
+							: {
+									organization: { createMany: { data: [{ organizationId: orgId }], skipDuplicates: true } },
+								}),
 					},
 					update: {
 						...record,

--- a/packages/ui/components/data-portal/EmailDrawer/index.tsx
+++ b/packages/ui/components/data-portal/EmailDrawer/index.tsx
@@ -104,12 +104,10 @@ export const _EmailDrawer = forwardRef<HTMLButtonElement, EmailDrawerProps>(
 		const [isSaved, setIsSaved] = useState(formIsDirty)
 
 		const emailUpdate = api.orgEmail.update.useMutation({
-			onSettled: (data) => {
+			onSuccess: (data) => {
+				setIsSaved(true)
 				apiUtils.orgEmail.invalidate()
 				reset(data)
-			},
-			onSuccess: () => {
-				setIsSaved(true)
 				notifySave()
 				modalHandler.close()
 				setTimeout(() => drawerHandler.close(), 500)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `update` functionality to conditionally create either `locations` or `organization` entries based on the presence of `linkLocationId`.
  
- **Refactor**
	- Streamlined the mutation handling in the `EmailDrawer` component to improve the logical flow by using a single `onSuccess` callback for state updates and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->