### PR TITLE
feat(app): ECB-56: temporarily set alertData to empty array so the alert page section is not displayed

### DIFF
--- a/apps/app/src/pages/org/[slug]/[orgLocationId]/edit.tsx
+++ b/apps/app/src/pages/org/[slug]/[orgLocationId]/edit.tsx
@@ -59,10 +59,7 @@ const OrgLocationPage: NextPage<InferGetServerSidePropsType<typeof getServerSide
 	const { data, status } = api.location.forLocationPageEdits.useQuery({ id: orgLocationId })
 	const { mutate: revalidatePage } = api.misc.revalidatePage.useMutation()
 
-	const { data: alertData } = api.location.getAlerts.useQuery(
-		{ id: orgLocationId },
-		{ enabled: router.isReady }
-	)
+	const { data: alertData } = { data: [] }
 
 	// for use with MultiSelectPopover
 

--- a/apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx
+++ b/apps/app/src/pages/org/[slug]/[orgLocationId]/index.tsx
@@ -53,10 +53,7 @@ const OrgLocationPage: NextPage = () => {
 		error: pageFetchError,
 	} = api.location.forLocationPage.useQuery({ id: orgLocationId }, { enabled: router.isReady })
 
-	const { data: alertData } = api.location.getAlerts.useQuery(
-		{ id: orgLocationId },
-		{ enabled: router.isReady }
-	)
+	const { data: alertData } = { data: [] }
 	const hasAlerts = useMemo(() => Array.isArray(alertData) && alertData.length > 0, [alertData])
 	const { classes } = useStyles()
 

--- a/apps/app/src/pages/org/[slug]/index.tsx
+++ b/apps/app/src/pages/org/[slug]/index.tsx
@@ -61,7 +61,7 @@ const OrganizationPage = ({
 			select: (serviceInfoResult) => serviceInfoResult.length !== 0,
 		}
 	)
-	const { data: alertData } = api.organization.getAlerts.useQuery({ slug }, { enabled: !!slug })
+	const { data: alertData } = { data: [] }
 	const hasAlerts = Array.isArray(alertData) && alertData.length > 0
 	const { ref, width } = useElementSize()
 	const { searchState } = useSearchState()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
it's not currently possible to edit an alert for an organization. 
an alert can be displayed for an organization or an organization location.
however, this data is extremely outdated.

Issue Number: N/A

## What is the new behavior?
to temporarily keep these alerts from being displayed in the UI the data alert array has been hardcoded to an empty array.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
