### PR TITLE
feat(app): remove Twitter/X as an option under Socials (ECB-67)

### DIFF
--- a/packages/db/prisma/data-migrations/2025-01-29_update-nationwide-locationbased-alert.ts
+++ b/packages/db/prisma/data-migrations/2025-01-29_update-nationwide-locationbased-alert.ts
@@ -34,12 +34,12 @@ export const job20250129_update_nationwide_locationbased_alert = {
 
 		const update2 = await prisma.locationAlert.update({
 			where: { id: 'alrt_01J1D1GAT5G5S6QNMCND5PMDAX' },
-			data: { level: 'INFO_PRIMARY' }, 
+			data: { level: 'INFO_PRIMARY' },
 		})
 
 		const update3 = await prisma.locationAlert.update({
 			where: { id: 'alrt_01J5XNBQ5GREHSHK5D2QTCXRWE' },
-			data: { active: true, level: 'WARN_SECONDARY' }, 
+			data: { active: true, level: 'WARN_SECONDARY' },
 		})
 
 		log(`Location-based alert text string updated: ${update1.key} with new text: "${update1.text}"`)

--- a/packages/db/prisma/data-migrations/2025-01-31_remove-twitter-from-SocialMediaServices.ts
+++ b/packages/db/prisma/data-migrations/2025-01-31_remove-twitter-from-SocialMediaServices.ts
@@ -1,0 +1,38 @@
+import { type MigrationJob } from '~db/prisma/dataMigrationRunner'
+import { type JobDef } from '~db/prisma/jobPreRun'
+
+/** Define the job metadata here. */
+const jobDef: JobDef = {
+	jobId: '2025-01-31_remove-twitter-from-SocialMediaServices',
+	title: 'remove twitter from social media services',
+	createdBy: 'Diana Garbarino',
+	/** Optional: Longer description for the job */
+	description: 'remove twitter from social media services',
+}
+/**
+ * Job export - this variable MUST be UNIQUE
+ */
+export const job20250131_remove_twitter_from_social_media_services = {
+	title: `[${jobDef.jobId}] ${jobDef.title}`,
+	task: async (ctx, task) => {
+		const { createLogger, formatMessage, jobPostRunner, prisma } = ctx
+		/** Create logging instance */
+		createLogger(task, jobDef.jobId)
+		const log = (...args: Parameters<typeof formatMessage>) => (task.output = formatMessage(...args))
+
+		const update = await prisma.socialMediaService.update({
+			where: { id: 'smsv_01GW2HHE8KK4BX2DXWGJ0187VJ' },
+			data: { active: false },
+		})
+
+		log(`set twitter active status to false`)
+
+		/**
+		 * DO NOT REMOVE BELOW
+		 *
+		 * This writes a record to the DB to register that this migration has run successfully.
+		 */
+		await jobPostRunner(jobDef)
+	},
+	def: jobDef,
+} satisfies MigrationJob

--- a/packages/db/prisma/data-migrations/2025-01-31_remove-twitter-from-orgWebsite-and-OrgSocialMedia.ts
+++ b/packages/db/prisma/data-migrations/2025-01-31_remove-twitter-from-orgWebsite-and-OrgSocialMedia.ts
@@ -1,0 +1,55 @@
+import { type MigrationJob } from '~db/prisma/dataMigrationRunner'
+import { type JobDef } from '~db/prisma/jobPreRun'
+
+/** Define the job metadata here. */
+const jobDef: JobDef = {
+	jobId: '2025-02-01_update-org-socialmedia-website-published',
+	title: 'Set published to false for Twitter/X URLs in OrgSocialMedia and OrgWebsite',
+	createdBy: 'Diana Garbarino',
+	description:
+		'Find all orgs with URLs starting with http(s)://twitter.com/ or http(s)://x.com/ and set published to false.',
+}
+
+/**
+ * Job export - this variable MUST be UNIQUE
+ */
+export const job20250201_update_org_socialmedia_website_published = {
+	title: `[${jobDef.jobId}] ${jobDef.title}`,
+	task: async (ctx, task) => {
+		const { createLogger, formatMessage, jobPostRunner, prisma } = ctx
+		/** Create logging instance */
+		createLogger(task, jobDef.jobId)
+		const log = (...args: Parameters<typeof formatMessage>) => (task.output = formatMessage(...args))
+
+		// Define conditions for both http and https URLs
+		const urlConditions = [
+			{ url: { startsWith: 'https://twitter.com/' } },
+			{ url: { startsWith: 'http://twitter.com/' } },
+			{ url: { startsWith: 'https://x.com/' } },
+			{ url: { startsWith: 'http://x.com/' } },
+		]
+
+		// Update OrgSocialMedia table
+		const socialMediaUpdate = await prisma.orgSocialMedia.updateMany({
+			where: { OR: urlConditions },
+			data: { published: false },
+		})
+
+		// Update OrgWebsite table
+		const websiteUpdate = await prisma.orgWebsite.updateMany({
+			where: { OR: urlConditions },
+			data: { published: false },
+		})
+
+		log(`Updated ${socialMediaUpdate.count} records in OrgSocialMedia to set published = false.`)
+		log(`Updated ${websiteUpdate.count} records in OrgWebsite to set published = false.`)
+
+		/**
+		 * DO NOT REMOVE BELOW
+		 *
+		 * This writes a record to the DB to register that this migration has run successfully.
+		 */
+		await jobPostRunner(jobDef)
+	},
+	def: jobDef,
+} satisfies MigrationJob

--- a/packages/db/prisma/data-migrations/index.ts
+++ b/packages/db/prisma/data-migrations/index.ts
@@ -19,4 +19,6 @@ export * from './2025-01-15_update-food-tags'
 export * from './2025-01-29_update-nationwide-locationbased-alert'
 export * from './2025-01-29_update-parent-category-for-trans-you-health'
 export * from './2025-01-29_update-translation-key-for-trans-health-youth'
+export * from './2025-01-31_remove-twitter-from-orgWebsite-and-OrgSocialMedia'
+export * from './2025-01-31_remove-twitter-from-SocialMediaServices'
 // codegen:end

--- a/packages/ui/components/core/SocialLink.stories.tsx
+++ b/packages/ui/components/core/SocialLink.stories.tsx
@@ -33,7 +33,6 @@ export const Group = {
 			{ icon: 'instagram', href: '#' },
 			{ icon: 'linkedin', href: '#' },
 			{ icon: 'tiktok', href: '#' },
-			{ icon: 'twitter', href: '#' },
 			{ icon: 'youtube', href: '#' },
 			{ icon: 'email', href: '#' },
 		],

--- a/packages/ui/components/core/SocialLink.tsx
+++ b/packages/ui/components/core/SocialLink.tsx
@@ -9,7 +9,6 @@ export const socialMediaIcons = {
 	email: 'carbon:email',
 	youtube: 'carbon:logo-youtube',
 	github: 'carbon:logo-github',
-	twitter: 'carbon:logo-twitter',
 	linkedin: 'carbon:logo-linkedin',
 	tiktok: 'simple-icons:tiktok',
 } as const

--- a/packages/ui/components/sections/Footer.tsx
+++ b/packages/ui/components/sections/Footer.tsx
@@ -161,7 +161,6 @@ export const Footer = () => {
 								href='https://www.facebook.com/weareinreach'
 								title={t('social.facebook', { defaultValue: 'Facebook' })}
 							/>
-							{/* <SocialLink icon='twitter' href='https://twitter.com/weareinreach' /> */}
 							<SocialLink
 								icon='linkedin'
 								href='https://www.linkedin.com/company/weareinreach'


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
currently if an organization has a Twitter or X link defined that link will appear in the socials section of the organization data
when orgs are created or edited it's possible to add twitter or X  social media links

Issue Number: N/A

## What is the new behavior?
made code changes so any of InReaches twitter/X details no longer appear within the app
made some data migrations to unpublish twitter/x data for any org
made some data migrations to remove twitter from the socials drop down so it can no longer be added to an org

the rest of the ticket, to add new values still needs to be completed as this will require additional language translations.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
