### PR TITLE
feat(app): add temp sign-up modal body that does not have LCR option

### DIFF
--- a/apps/app/public/locales/af/common.json
+++ b/apps/app/public/locales/af/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individueel</button>\n<button data-option='provider'>Professioneel/Verskaffer</button>\n<button data-option='lcr'>Plaaslik Gemeenskapresensent</button>\n</group>",
 			"<loginLink>Het u reeds 'n rekening?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Watter tipe rekening wil jy skep?</title3>",
+			"<group>\n<button data-option='individual'>Individueel</button>\n<button data-option='provider'>Professioneel/Verskaffer</button>\n</group>",
+			"<loginLink>Het u reeds 'n rekening?</loginLink>"
+		],
 		"name-use-any": "Gebruik watter naam jy ook al gemaklik is.",
 		"name_alias": "Naam of alias",
 		"name_full": "Volle naam",

--- a/apps/app/public/locales/ar/common.json
+++ b/apps/app/public/locales/ar/common.json
@@ -334,6 +334,11 @@
 			"<group>\n<button data-option='individual'>فردي</button>\n<button data-option='provider'>المحترف / المزود</button>\n<button data-option='lcr'>مستعرض المجتمع المحلي</button>\n</group>",
 			"<loginLink>لديك حساب من قبل؟</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>ما نوع الحساب الذي ترغب في إنشاءه؟</title3>",
+			"<group>\n<button data-option='individual'>فردي</button>\n<button data-option='provider'>المحترف / المزود</button>\n</group>",
+			"<loginLink>لديك حساب من قبل؟</loginLink>"
+		],
 		"name-use-any": "استخدم أي اسم أنت مرتاحاً له.",
 		"name_alias": "الاسم أو الاسم المستعار",
 		"name_full": "الاسم الكامل",

--- a/apps/app/public/locales/de-DE/common.json
+++ b/apps/app/public/locales/de-DE/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individuelle</button>\n<button data-option='provider'>Professional/Anbieter</button>\n<button data-option='lcr'>Lokale Community Reviewer</button>\n</group>",
 			"<loginLink>Haben Sie bereits ein Konto?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Welchen Kontotyp möchten Sie erstellen?</title3>",
+			"<group>\n<button data-option='individual'>Individuelle</button>\n<button data-option='provider'>Professional/Anbieter</button>\n</group>",
+			"<loginLink>Haben Sie bereits ein Konto?</loginLink>"
+		],
 		"name-use-any": "Benutzen Sie den Namen, mit dem Sie sich wohl fühlen.",
 		"name_alias": "Name oder Alias",
 		"name_full": "Voller Name",

--- a/apps/app/public/locales/en/common.json
+++ b/apps/app/public/locales/en/common.json
@@ -336,6 +336,11 @@
 			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Local Community Reviewer</button>\n</group>",
 			"<loginLink>Already have an account?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>What type of account would you like to create?</title3>",
+			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n</group>",
+			"<loginLink>Already have an account?</loginLink>"
+		],
 		"name-use-any": "Use whatever name you're comfortable with.",
 		"name_alias": "Name or alias",
 		"name_full": "Full name",

--- a/apps/app/public/locales/es/common.json
+++ b/apps/app/public/locales/es/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Profesional/Proveedor</button>\n<button data-option='lcr'>Revisor de Comunidad Local</button>\n</group>",
 			"<loginLink>¿Ya tienes una cuenta?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>¿Qué tipo de cuenta quieres crear?</title3>",
+			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Profesional/Proveedor</button>\n</group>",
+			"<loginLink>¿Ya tienes una cuenta?</loginLink>"
+		],
 		"name-use-any": "Usa el nombre con el que te sientas cómodo.",
 		"name_alias": "Nombre o alias",
 		"name_full": "Nombre completo",

--- a/apps/app/public/locales/fa/common.json
+++ b/apps/app/public/locales/fa/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Local Community Reviewer</button>\n</group>",
 			"<loginLink>از قبل حساب کاربری دارید؟</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>چه نوع حساب کاربری می خواهید ایجاد کنید؟</title3>",
+			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n</group>",
+			"<loginLink>از قبل حساب کاربری دارید؟</loginLink>"
+		],
 		"name-use-any": "از هر اسمي که باهاش راحت هستي استفاده کن",
 		"name_alias": "نام یا نام مستعار",
 		"name_full": "نام کامل",

--- a/apps/app/public/locales/fr/common.json
+++ b/apps/app/public/locales/fr/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individuel</button>\n<button data-option='provider'>Professionnel/Prestataire</button>\n<button data-option='lcr'>Critique dans la communauté locale</button>\n</group>",
 			"<loginLink>Vous avez déjà un compte ?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Quel type de compte voulez-vous créer ?</title3>",
+			"<group>\n<button data-option='individual'>Individuel</button>\n<button data-option='provider'>Professionnel/Prestataire</button>\n</group>",
+			"<loginLink>Vous avez déjà un compte ?</loginLink>"
+		],
 		"name-use-any": "Utilisez le nom qui vous convient le mieux.",
 		"name_alias": "Nom ou alias",
 		"name_full": "Nom complet",

--- a/apps/app/public/locales/hi/common.json
+++ b/apps/app/public/locales/hi/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Local Community Reviewer</button>\n</group>",
 			"<loginLink>क्या आपके पास पहले से ही एक अकाउंट है?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>आप किस प्रकार का अकाउंट बनाना चाहेंगे?</title3>",
+			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n</group>",
+			"<loginLink>क्या आपके पास पहले से ही एक अकाउंट है?</loginLink>"
+		],
 		"name-use-any": "जिस भी नाम के साथ आप सहज हों उसका उपयोग करें।",
 		"name_alias": "नाम या उपनाम",
 		"name_full": "पूरा नाम",

--- a/apps/app/public/locales/ht/common.json
+++ b/apps/app/public/locales/ht/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Endividyèl</button>\n<button data-option='provider'>Pwofesyonèl/Founisè</button>\n<button data-option='lcr'>Lokal Evalè Kominote</button>\n</group>",
 			"<loginLink>Deja gen yon kont?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Ki kalite kont ou ta renmen kreye?</title3>",
+			"<group>\n<button data-option='individual'>Endividyèl</button>\n<button data-option='provider'>Pwofesyonèl/Founisè</button>\n</group>",
+			"<loginLink>Deja gen yon kont?</loginLink>"
+		],
 		"name-use-any": "Sèvi ak tou sa non ou konfòtab avèk li.",
 		"name_alias": "Non oswa alyas",
 		"name_full": "Non konplè",

--- a/apps/app/public/locales/ja/common.json
+++ b/apps/app/public/locales/ja/common.json
@@ -329,6 +329,11 @@
 			"<group>\n<button data-option='individual'>個人</button>\n<button data-option='provider'>専門家/提供者</button>\n<button data-option='lcr'>地域コミュニティレビュアー</button>\n</group>",
 			"<loginLink>すでにアカウントをお持ちですか？</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>どのタイプのアカウントを作成しますか?</title3>",
+			"<group>\n<button data-option='individual'>個人</button>\n<button data-option='provider'>専門家/提供者</button>\n</group>",
+			"<loginLink>すでにアカウントをお持ちですか？</loginLink>"
+		],
 		"name-use-any": "自身にとって快適な名前をお使いください。",
 		"name_alias": "名前または別名",
 		"name_full": "フルネーム",

--- a/apps/app/public/locales/ko/common.json
+++ b/apps/app/public/locales/ko/common.json
@@ -329,6 +329,11 @@
 			"<group>\n<button data-option='individual'>개인</button>\n<button data-option='provider'>전문가/제공자</button>\n<button data-option='lcr'>지역 사회 검토자</button>\n</group>",
 			"<loginLink>계정 이미 있습니다.</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>어떤 계정을 만들고 싶으세요?</title3>",
+			"<group>\n<button data-option='individual'>개인</button>\n<button data-option='provider'>전문가/제공자</button>\n</group>",
+			"<loginLink>계정 이미 있습니다.</loginLink>"
+		],
 		"name-use-any": "편한 이름을 사용하세요.",
 		"name_alias": "성함/가명",
 		"name_full": "성함",

--- a/apps/app/public/locales/pl/common.json
+++ b/apps/app/public/locales/pl/common.json
@@ -332,6 +332,11 @@
 			"<group>\n<button data-option='individual'>Indywidualny</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Lokalny recenzenta społeczności</button>\n</group>",
 			"<loginLink>Masz już konto?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Jaki typ konta chciałbyś założyć?</title3>",
+			"<group>\n<button data-option='individual'>Indywidualny</button>\n<button data-option='provider'>Professional/Provider</button>\n</group>",
+			"<loginLink>Masz już konto?</loginLink>"
+		],
 		"name-use-any": "Używaj dowolnej nazwy, z którą czujesz się komfortowo.",
 		"name_alias": "Nazwa lub alias",
 		"name_full": "Pełne imię i nazwisko",

--- a/apps/app/public/locales/ps/common.json
+++ b/apps/app/public/locales/ps/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Local Community Reviewer</button>\n</group>",
 			"<loginLink>دمخه یو حساب لرئ؟</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>تاسو کوم ډول حساب جوړول غواړئ؟</title3>",
+			"<group>\n<button data-option='individual'>Individual</button>\n<button data-option='provider'>Professional/Provider</button>`\n</group>",
+			"<loginLink>دمخه یو حساب لرئ؟</loginLink>"
+		],
 		"name-use-any": "هر هغه نوم وکاروئ چې تاسو ورسره راحته یاست.",
 		"name_alias": "نوم یا عرف",
 		"name_full": "بشپړ نوم",

--- a/apps/app/public/locales/pt/common.json
+++ b/apps/app/public/locales/pt/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Pessoa</button>\n<button data-option='provider'>Profissional/Pessoa provedora</button>\n<button data-option='lcr'>Pessoa Avaliadora da Comunidade Local</button>\n</group>",
 			"<loginLink>Já tem uma conta?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Que tipo de conta você gostaria de criar?</title3>",
+			"<group>\n<button data-option='individual'>Pessoa</button>\n<button data-option='provider'>Profissional/Pessoa provedora</button>\n</group>",
+			"<loginLink>Já tem uma conta?</loginLink>"
+		],
 		"name-use-any": "Use qualquer nome com o qual você se sinta confortável.",
 		"name_alias": "Nome ou apelido",
 		"name_full": "Nome completo",

--- a/apps/app/public/locales/ru/common.json
+++ b/apps/app/public/locales/ru/common.json
@@ -332,6 +332,11 @@
 			"<group>\n<button data-option='individual'>Индивидуальная</button>\n<button data-option='provider'>Профессионал/ресурс</button>\n<button data-option='lcr'>Обозреватель услуг для местного населения</button>\n</group>",
 			"<loginLink>У вас уже есть аккаунт?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Какой тип учетной записи вы хотели бы создать?</title3>",
+			"<group>\n<button data-option='individual'>Индивидуальная</button>\n<button data-option='provider'>Профессионал/ресурс</button>\n</group>",
+			"<loginLink>У вас уже есть аккаунт?</loginLink>"
+		],
 		"name-use-any": "Вы можете использовать любое имя, которое вам нравится.",
 		"name_alias": "Имя или псевдоним",
 		"name_full": "Полное имя",

--- a/apps/app/public/locales/sw/common.json
+++ b/apps/app/public/locales/sw/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Mtu binafsi</button>\n<button data-option='provider'>Mtaalamu/Mtoa huduma</button>\n<button data-option='lcr'>Mitaa Mkaguzi wa Jumuiya</button>\n</group>",
 			"<loginLink>Tayari una akaunti?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Je! Ungependa kuunda akaunti ya aina gani?</title3>",
+			"<group>\n<button data-option='individual'>Mtu binafsi</button>\n<button data-option='provider'>Mtaalamu/Mtoa huduma</button>\n</group>",
+			"<loginLink>Tayari una akaunti?</loginLink>"
+		],
 		"name-use-any": "Tumia jina lolote unalostahili.",
 		"name_alias": "Jina au pak",
 		"name_full": "Jina kamili",

--- a/apps/app/public/locales/tl/common.json
+++ b/apps/app/public/locales/tl/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Indibidwal</button>\n<button data-option='provider'>Propesyonal/Provider</button>\n<button data-option='lcr'>Lokal Tagasuri ng Komunidad</button>\n</group>",
 			"<loginLink>Mayroon nang isang account?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Anong uri ng account ang nais mong likhain?</title3>",
+			"<group>\n<button data-option='individual'>Indibidwal</button>\n<button data-option='provider'>Propesyonal/Provider</button>\n</group>",
+			"<loginLink>Mayroon nang isang account?</loginLink>"
+		],
 		"name-use-any": "Gamitin ang anumang pangalan na komportable ka.",
 		"name_alias": "Pangalan o alyas",
 		"name_full": "Buong pangalan",

--- a/apps/app/public/locales/tr-TR/common.json
+++ b/apps/app/public/locales/tr-TR/common.json
@@ -330,6 +330,11 @@
 			"<group>\n<button data-option='individual'>Bireysel</button>\n<button data-option='provider'>Profesyonel/Sağlayıcı</button>\n<button data-option='lcr'>Yerel Topluluk İncelemesi</button>\n</group>",
 			"<loginLink>Zaten bir hesabınız var mı?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Ne tür bir hesap oluşturmak istersiniz?</title3>",
+			"<group>\n<button data-option='individual'>Bireysel</button>\n<button data-option='provider'>Profesyonel/Sağlayıcı</button>\n</group>",
+			"<loginLink>Zaten bir hesabınız var mı?</loginLink>"
+		],
 		"name-use-any": "Rahat olduğunuz ismi kullanın.",
 		"name_alias": "İsim veya takma ad",
 		"name_full": "Ad Soyad",

--- a/apps/app/public/locales/uk/common.json
+++ b/apps/app/public/locales/uk/common.json
@@ -332,6 +332,11 @@
 			"<group>\n<button data-option='individual'>Індивідуальний</button>\n<button data-option='provider'>Professional/Provider</button>\n<button data-option='lcr'>Локальний оглядач спільноти</button>\n</group>",
 			"<loginLink>Вже є обліковий запис?</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>Який тип облікового запису ви хотіли б створити?</title3>",
+			"<group>\n<button data-option='individual'>Індивідуальний</button>\n<button data-option='provider'>Professional/Provider</button>\n</group>",
+			"<loginLink>Вже є обліковий запис?</loginLink>"
+		],
 		"name-use-any": "Використовуйте будь-яке ім'я, яке вам зручно.",
 		"name_alias": "Ім'я або псевдонім",
 		"name_full": "П.І.Б.",

--- a/apps/app/public/locales/zh/common.json
+++ b/apps/app/public/locales/zh/common.json
@@ -329,6 +329,11 @@
 			"<group>\n<button data-option='individual'>个人</button>\n<button data-option='provider'>专业人士/提供商</button>\n<button data-option='lcr'>本地社区评论家</button>\n</group>",
 			"<loginLink>已有帐号？</loginLink>"
 		],
+		"modal-body-temp": [
+			"<title3>你想创建什么类型的账户？</title3>",
+			"<group>\n<button data-option='individual'>个人</button>\n<button data-option='provider'>专业人士/提供商</button>\n</group>",
+			"<loginLink>已有帐号？</loginLink>"
+		],
 		"name-use-any": "使用您喜欢的任何名称。",
 		"name_alias": "姓名或别名",
 		"name_full": "全名",

--- a/packages/ui/modals/LoginSignUp/index.tsx
+++ b/packages/ui/modals/LoginSignUp/index.tsx
@@ -196,7 +196,9 @@ const SignUpModalBody = forwardRef<HTMLButtonElement, SignUpModalBodyProps>((pro
 		: t('step-x-y', { ns: 'common', x: stepOption ? 2 : 1, y: 2 })
 	const modalTitle = <ModalTitle breadcrumb={breadcrumbProps} rightText={titleRightSideProps} />
 
-	const step1 = <RichTranslate i18nKey='sign-up.modal-body' stateSetter={userTypeChange} handler={handler} />
+	const step1 = (
+		<RichTranslate i18nKey='sign-up.modal-body-temp' stateSetter={userTypeChange} handler={handler} />
+	)
 
 	const submitHandler = () => {
 		if (form.isValid()) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
app is currently using sign-up.modal-body to pull button options from the common.json file for each language. the button for the 'lcr' option is located here.

Issue Number: N/A

## What is the new behavior?
since this change is designed to be temporary, I created a modal-body-temp section in the common.json files and pointed the signup component to use this temporary modal-body section. This way, when the 'lcr' feature is ready to be added back, the translations will not need to be re-done.

to change things back:
change this:
	const step1 = (
		<RichTranslate i18nKey='sign-up.modal-body-temp' stateSetter={userTypeChange} handler={handler} />
	)
to this:
	const step1 = (
		<RichTranslate i18nKey='sign-up.modal-body' stateSetter={userTypeChange} handler={handler} />
	)

Then - remove modal-body-temp from the various common.js files.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
