### PR TITLE
feat(app): replace Claimed and Unclaimed badge with Coming soon link

### DIFF
--- a/.github/autoapprove-config.yaml
+++ b/.github/autoapprove-config.yaml
@@ -1,5 +1,5 @@
 ---
 requesters:
-  joekarow:
+  trigal2012:
     labels:
       - automerge

--- a/packages/ui/components/core/Badge/Claimed.tsx
+++ b/packages/ui/components/core/Badge/Claimed.tsx
@@ -30,6 +30,13 @@ export const _Claimed = forwardRef<HTMLDivElement, BadgeClaimedProps>(
 			...props,
 		} as const
 
+		const badgePropsTemp = {
+			variant: 'outline',
+			classNames: classes,
+			...(isClaimed ? { ref } : {}),
+			...props,
+		} as const
+
 		const badge = isClaimed ? (
 			<Badge {...badgeProps}>
 				<Text>{t('badge.claimed')}</Text>
@@ -37,6 +44,7 @@ export const _Claimed = forwardRef<HTMLDivElement, BadgeClaimedProps>(
 		) : (
 			<Text>{t('badge.unclaimed')}</Text>
 		)
+
 		const label = isClaimed ? (
 			<Trans
 				i18nKey='badge.claimed-tool-tip'
@@ -86,12 +94,21 @@ export const _Claimed = forwardRef<HTMLDivElement, BadgeClaimedProps>(
 			className: classes.root,
 		} as const
 
-		return isClaimed ? (
-			<Tooltip {...tooltipProps}>{badge}</Tooltip>
-		) : (
-			<Tooltip {...tooltipProps}>
-				<ClaimOrgModal {...claimOrgModalProps}>{badge}</ClaimOrgModal>
-			</Tooltip>
+		const claimOrgModalPropsTemp = {
+			component: Badge,
+			...badgePropsTemp,
+			w: 'fit-content',
+			externalOpen: modalOpen,
+			externalStateHandler: setModalOpen,
+			className: classes.root,
+		} as const
+
+		return (
+			<ClaimOrgModal {...claimOrgModalPropsTemp}>
+				<Link external onClick={() => setModalOpen(true)} variant={variants.Link.inheritStyle}>
+					{t('words.coming-soon')}
+				</Link>
+			</ClaimOrgModal>
 		)
 	}
 )


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Organizations have badges which indicate if they have been claimed or not. The badge display is correct but the ability to claim an organization is not yet functional.

Issue Number: N/A

## What is the new behavior?
With this PR, the badges are replaced with a Coming soon link, which when clicked explains the claim and unclaimed details. the modal indicates that the feature is not yet available.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
