### PR TITLE
feat(app): ECB-101 added support for search/intl/ route

### DIFF
--- a/apps/app/public/locales/en/common.json
+++ b/apps/app/public/locales/en/common.json
@@ -82,6 +82,7 @@
 		"natl-find-help-now": "Find help now",
 		"natl-these-verified": "<Text>These verified resources can help the LGBTQ+ community in the United States. These services are <strong>remotely available, confidential,</strong> and <strong>free</strong>.</Text>",
 		"outside-service-area": "InReach does not operate in {{country}}",
+		"only-in-north-america": "InReach only operates in North America.",
 		"who-this-serves": "<Text><strong>Who this resource serves:</strong> {{targetPop}}</Text>"
 	},
 	"current-location": "Current location",

--- a/apps/app/public/locales/uk/common.json
+++ b/apps/app/public/locales/uk/common.json
@@ -84,6 +84,7 @@
 		"natl-find-help-now": "Знайти допомогу зараз",
 		"natl-these-verified": "<Text>These verified resources can help the LGBTQ+ community in the United States. These services are <strong>remotely available, confidential,</strong> and <strong>free</strong>.</Text>",
 		"outside-service-area": "InReach does not operate in {{country}}",
+		"only-in-north-america": "InReach only operates in North America.",
 		"who-this-serves": "<Text><strong>Who this resource serves:</strong> {{targetPop}}</Text>"
 	},
 	"current-location": "Поточне місцезнаходження",

--- a/apps/app/src/pages/search/intl/index.tsx
+++ b/apps/app/src/pages/search/intl/index.tsx
@@ -1,0 +1,161 @@
+// import { type GetServerSideProps } from 'next'
+import {
+	createStyles,
+	Divider,
+	Grid,
+	Group,
+	rem,
+	Skeleton,
+	Stack,
+	Text,
+	Title,
+	useMantineTheme,
+} from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
+import { type GetStaticProps } from 'next'
+import dynamic from 'next/dynamic'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { useEffect, useState } from 'react'
+import { z } from 'zod'
+
+import { trpcServerClient } from '@weareinreach/api/trpc'
+import { SearchBox } from '@weareinreach/ui/components/core/SearchBox'
+import { CrisisSupport } from '@weareinreach/ui/components/sections/CrisisSupport'
+import { SearchResultSidebar } from '@weareinreach/ui/components/sections/SearchResultSidebar'
+import { useCustomVariant } from '@weareinreach/ui/hooks/useCustomVariant'
+import { api } from '~app/utils/api'
+import { getServerSideTranslations } from '~app/utils/i18n'
+
+const MoreFilter = dynamic(() => import('@weareinreach/ui/modals/MoreFilter').then((mod) => mod.MoreFilter))
+const ServiceFilter = dynamic(() =>
+	import('@weareinreach/ui/modals/ServiceFilter').then((mod) => mod.ServiceFilter)
+)
+const useStyles = createStyles((theme) => ({
+	searchControls: {
+		flexWrap: 'wrap',
+		flexDirection: 'column',
+		[theme.fn.largerThan('sm')]: {
+			flexWrap: 'nowrap',
+			flexDirection: 'row',
+		},
+	},
+	hideMobile: {
+		[theme.fn.smallerThan('sm')]: {
+			display: 'none',
+		},
+	},
+	parentCard: {
+		background: theme.other.colors.tertiary.yellow,
+	},
+	categoryBadge: {
+		background: theme.other.colors.secondary.white,
+	},
+	staySafeCard: {
+		border: `${rem(1)} solid ${theme.other.colors.secondary.white}`,
+		borderRadius: rem(16),
+	},
+	getHelpCard: {
+		border: `${rem(1)} solid ${theme.other.colors.tertiary.coolGray}`,
+		borderRadius: rem(16),
+	},
+	cardShadow: {
+		boxShadow: `${rem(0)} ${rem(4)} ${rem(20)} ${rem(0)} rgba(0, 0, 0, 0.1)`,
+	},
+}))
+
+const notBlank = (value?: string) => !!value && value.length > 0
+
+const OutsideServiceArea = () => {
+	const [loading, setLoading] = useState(false)
+	const { classes } = useStyles()
+	const variants = useCustomVariant()
+	const theme = useMantineTheme()
+	const isTablet = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`)
+	const router = useRouter()
+
+	useEffect(() => {
+		if (!router.isReady && !loading) {
+			setLoading(true)
+		} else if (router.isReady && loading) {
+			setLoading(false)
+		}
+	}, [router.isReady, router.isFallback, loading])
+
+	const { data } = api.organization.getIntlCrisis.useQuery(
+		{ cca2: 'AU' },
+		{ enabled: notBlank('AU'), onSuccess: () => setLoading(false) }
+	)
+	const { t } = useTranslation(['services', 'common', 'attribute'])
+
+	const resultCount = 0
+
+	return (
+		<>
+			<Head>
+				<title>{t('page-title.base', { ns: 'common', title: '$t(page-title.search-results)' })}</title>
+			</Head>
+			<Grid.Col xs={12} sm={12} pb={30}>
+				<Group spacing={20} w='100%' className={classes.searchControls}>
+					<Group maw={{ md: '50%', base: '100%' }} w='100%'>
+						<SearchBox type='location' loadingManager={{ setLoading, isLoading: loading }} />
+					</Group>
+					<Group noWrap w={{ base: '100%', md: '50%' }}>
+						<ServiceFilter resultCount={resultCount} isFetching={false} disabled />
+						{/* @ts-expect-error `component` prop not needed.. */}
+						<MoreFilter resultCount={resultCount} isFetching={false} disabled>
+							{t('more.filters')}
+						</MoreFilter>
+					</Group>
+					{isTablet && (
+						<>
+							<Divider w='100%' />
+							<Skeleton visible={typeof resultCount !== 'number'}>
+								<Text variant={variants.Text.utility1}>
+									{t('common:count.result', { count: resultCount })}
+								</Text>
+							</Skeleton>
+						</>
+					)}
+				</Group>
+			</Grid.Col>
+			<Grid.Col className={classes.hideMobile}>
+				<SearchResultSidebar resultCount={resultCount} loadingManager={{ setLoading, isLoading: loading }} />
+			</Grid.Col>
+			<Grid.Col xs={12} sm={8} md={8}>
+				<Stack spacing={48}>
+					<Title order={2}>
+						<Skeleton visible={loading}>{t('common:crisis-support.only-in-north-america')}</Skeleton>{' '}
+					</Title>
+					<Skeleton visible={loading}>
+						<CrisisSupport role='international'>
+							{data?.map((resource) => <CrisisSupport.International data={resource} key={resource.id} />)}
+						</CrisisSupport>
+					</Skeleton>
+				</Stack>
+			</Grid.Col>
+		</>
+	)
+}
+
+export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
+	const ssg = await trpcServerClient({ session: null })
+	const [i18n] = await Promise.allSettled([
+		getServerSideTranslations(locale, ['services', 'common', 'attribute']),
+		ssg.organization.getIntlCrisis.prefetch({ cca2: 'AU' }),
+	])
+
+	const props = {
+		trpcState: ssg.dehydrate(),
+		...(i18n.status === 'fulfilled' ? i18n.value : {}),
+	}
+
+	return {
+		props,
+		revalidate: 60 * 60 * 24 * 7, // 7 days
+	}
+}
+
+OutsideServiceArea.autoResetState = true
+export default OutsideServiceArea


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no route support for a generic international landing page at search/intl
users must search based on a country first

Issue Number: N/A

## What is the new behavior?

this PR provides a basic route for /search/intl which brings users to a basic international landing page. 
the title reads "InReach only operates in North America." then lists information for a few international resources.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
