### PR TITLE
bugfix(app): ensure long url links wrap on the International page info cards

### DIFF
--- a/packages/ui/components/sections/CrisisSupport/InternationalCard.tsx
+++ b/packages/ui/components/sections/CrisisSupport/InternationalCard.tsx
@@ -82,6 +82,7 @@ export const InternationalCard = ({
 													external
 													variant={variant.Link.inheritStyle}
 													key={`${i}-${access_type}`}
+													style={{ overflowWrap: 'anywhere', whiteSpace: 'normal' }}
 												>
 													{access_value.replace(protocol, '')}
 												</Link>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

on the international support page /search/intl/{country}, website URLs would wrao but could still be too long for the parent container, depending on the device size used to view the results. i.e mobile.

Issue Number: N/A

## What is the new behavior?

added some inline styles to ensure the url link would wrap based on the size of the parent div container

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
