### PR TITLE
feat: Make URL required for "Suggest an Org" form

### DIFF
--- a/packages/api/router/organization/mutation.createNewSuggestion.handler.ts
+++ b/packages/api/router/organization/mutation.createNewSuggestion.handler.ts
@@ -1,3 +1,5 @@
+import { TRPCError } from '@trpc/server'
+
 import { generateId, getAuditedClient } from '@weareinreach/db'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
@@ -14,6 +16,29 @@ const createNewSuggestion = async ({
 	// If any operation fails, the entire transaction is rolled back.
 	const result = await prisma.$transaction(async (tx) => {
 		console.log('Starting transaction for organization suggestion.')
+
+		if (!existingOrgId) {
+			// Normalize down to the bare domain, the same way query.getPotentialMatches does, so
+			// "already flagged while typing" and "blocked on submit" agree on what counts as a duplicate.
+			const normalizedWebsite = orgWebsite
+				.trim()
+				.toLowerCase()
+				.replace(/^https?:\/\//, '')
+				.replace(/^www\./, '')
+				.split(/[/?#]/)[0]
+			const existingWebsiteMatch = await tx.$queryRaw<{ organizationId: string }[]>`
+				SELECT "organizationId"
+				FROM "OrgWebsite"
+				WHERE regexp_replace(lower(url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite}
+				LIMIT 1
+			`
+			if (existingWebsiteMatch.length > 0) {
+				throw new TRPCError({
+					code: 'CONFLICT',
+					message: 'This website is already associated with an existing organization in our system.',
+				})
+			}
+		}
 
 		let organizationId = existingOrgId
 

--- a/packages/api/router/organization/mutation.createNewSuggestion.handler.ts
+++ b/packages/api/router/organization/mutation.createNewSuggestion.handler.ts
@@ -5,6 +5,16 @@ import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TCreateNewSuggestionSchema } from './mutation.createNewSuggestion.schema'
 
+// Reduces a URL to its bare domain - strips protocol, "www.", and everything from the first /, ?, or #
+// onward - so "https://www.example.org/donate" and "example.org" are treated as the same organization.
+const normalizeToDomain = (url: string) =>
+	url
+		.trim()
+		.toLowerCase()
+		.replace(/^https?:\/\//, '')
+		.replace(/^www\./, '')
+		.split(/[/?#]/)[0] ?? ''
+
 const createNewSuggestion = async ({
 	ctx,
 	input,
@@ -20,19 +30,17 @@ const createNewSuggestion = async ({
 		if (!existingOrgId) {
 			// Normalize down to the bare domain, the same way query.getPotentialMatches does, so
 			// "already flagged while typing" and "blocked on submit" agree on what counts as a duplicate.
-			const normalizedWebsite = orgWebsite
-				.trim()
-				.toLowerCase()
-				.replace(/^https?:\/\//, '')
-				.replace(/^www\./, '')
-				.split(/[/?#]/)[0]
-			const existingWebsiteMatch = await tx.$queryRaw<{ organizationId: string }[]>`
-				SELECT "organizationId"
-				FROM "OrgWebsite"
-				WHERE regexp_replace(lower(url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite}
-				LIMIT 1
-			`
-			if (existingWebsiteMatch.length > 0) {
+			// A broad substring pre-filter narrows the candidates cheaply, then the exact domain
+			// comparison happens in JS - this avoids hand-rolling regex/backreference logic in raw SQL.
+			const normalizedWebsite = normalizeToDomain(orgWebsite)
+			const candidates = await tx.orgWebsite.findMany({
+				where: { url: { contains: normalizedWebsite, mode: 'insensitive' } },
+				select: { url: true },
+			})
+			const isDuplicate = candidates.some(
+				(candidate) => normalizeToDomain(candidate.url) === normalizedWebsite
+			)
+			if (isDuplicate) {
 				throw new TRPCError({
 					code: 'CONFLICT',
 					message: 'This website is already associated with an existing organization in our system.',

--- a/packages/api/router/organization/mutation.createNewSuggestion.schema.ts
+++ b/packages/api/router/organization/mutation.createNewSuggestion.schema.ts
@@ -6,7 +6,7 @@ export const ZCreateNewSuggestionSchema = z.object({
 	countryId: prefixedId('country'),
 	orgName: z.string().trim().min(2),
 	orgSlug: z.string().regex(/^[A-Za-z0-9-]*$/, 'Slug must only contain letters, numbers, and hyphens'),
-	orgWebsite: z.string().trim().url().optional(),
+	orgWebsite: z.string().trim().min(1, 'Organization website is required').url(),
 	orgAddress: z
 		.object({
 			street1: z.string(),

--- a/packages/api/router/organization/mutation.createNewSuggestion.schema.ts
+++ b/packages/api/router/organization/mutation.createNewSuggestion.schema.ts
@@ -2,11 +2,49 @@ import { z } from 'zod'
 
 import { prefixedId } from '~api/schemas/idPrefix'
 
+// Not exhaustive of every IANA TLD - just the ones realistically expected for an org located in the
+// countries this form currently accepts (US, Mexico, Canada), plus common generic TLDs. Catches typos
+// like "aclu.or" (missing the final letter) that `.url()` alone can't detect.
+const ALLOWED_TLDS = new Set([
+	'com',
+	'org',
+	'net',
+	'edu',
+	'gov',
+	'mil',
+	'info',
+	'biz',
+	'co',
+	'io',
+	'app',
+	'me',
+	'us',
+	'mx',
+	'ca',
+])
+
+const hasValidTld = (url: string) => {
+	try {
+		const tld = new URL(url).hostname.split('.').pop()?.toLowerCase()
+		return Boolean(tld && ALLOWED_TLDS.has(tld))
+	} catch {
+		return false
+	}
+}
+
 export const ZCreateNewSuggestionSchema = z.object({
 	countryId: prefixedId('country'),
 	orgName: z.string().trim().min(2),
 	orgSlug: z.string().regex(/^[A-Za-z0-9-]*$/, 'Slug must only contain letters, numbers, and hyphens'),
-	orgWebsite: z.string().trim().min(1, 'Organization website is required').url(),
+	orgWebsite: z
+		.string()
+		.trim()
+		.min(1, 'Organization website is required')
+		.url('Please enter a valid, complete URL (e.g. https://example.org)')
+		.refine(hasValidTld, {
+			message:
+				"That doesn't look like a valid website address - please double check for typos (e.g. https://example.org)",
+		}),
 	orgAddress: z
 		.object({
 			street1: z.string(),

--- a/packages/api/router/organization/query.getPotentialMatches.handler.ts
+++ b/packages/api/router/organization/query.getPotentialMatches.handler.ts
@@ -5,6 +5,46 @@ import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TGetPotentialMatchesSchema } from './query.getPotentialMatches.schema'
 
+// Reduces a URL to its bare domain - strips protocol, "www.", and everything from the first /, ?, or #
+// onward - so "https://www.example.org/donate" and "example.org" are treated as the same organization.
+const normalizeToDomain = (url: string) =>
+	url
+		.trim()
+		.toLowerCase()
+		.replace(/^https?:\/\//, '')
+		.replace(/^www\./, '')
+		.split(/[/?#]/)[0] ?? ''
+
+const levenshteinDistance = (a: string, b: string) => {
+	const rows = Array.from({ length: a.length + 1 }, (_, i) =>
+		Array.from({ length: b.length + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+	)
+	for (let i = 1; i <= a.length; i++) {
+		for (let j = 1; j <= b.length; j++) {
+			const row = rows[i]
+			const prevRow = rows[i - 1]
+			if (!row || !prevRow) continue
+			row[j] =
+				a[i - 1] === b[j - 1]
+					? (prevRow[j - 1] ?? 0)
+					: 1 + Math.min(prevRow[j] ?? 0, row[j - 1] ?? 0, prevRow[j - 1] ?? 0)
+		}
+	}
+	return rows[a.length]?.[b.length] ?? Math.max(a.length, b.length)
+}
+
+const NEAR_MISS_MAX_DISTANCE = 2
+
+type MatchRow = {
+	id: string
+	name: string
+	slug: string
+	city: string | null
+	state: string | null
+	deleted: boolean
+	published: boolean
+}
+
 const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMatchesSchema>) => {
 	const { name, website } = input
 
@@ -36,33 +76,31 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 			? Prisma.sql`ARRAY[${Prisma.join(uniqueExpandedTerms.map((t) => `%${t.replace(/[^a-zA-Z0-9 ]/g, '')}%`))}]`
 			: Prisma.sql`ARRAY[]::text[]`
 
-	// Normalize website down to its bare domain (strip protocol, www, and everything from the first
-	// /, ?, or # onward) so "https://www.example.org/donate" and "example.org" count as the same site.
-	const normalizedWebsite = website
-		? website
-				.trim()
-				.toLowerCase()
-				.replace(/^https?:\/\//, '')
-				.replace(/^www\./, '')
-				.split(/[/?#]/)[0]
-		: undefined
+	const normalizedWebsite = website ? normalizeToDomain(website) : undefined
+
+	// Website duplicates: a broad substring pre-filter in SQL (via Prisma's query builder, not raw SQL),
+	// then an exact domain comparison in JS - avoids hand-rolling regex/backreference logic in raw SQL,
+	// which proved fragile (both a SQL syntax error and a silent false-negative in practice).
+	let websiteMatchOrgIds = new Set<string>()
+	if (normalizedWebsite) {
+		const candidates = await prisma.orgWebsite.findMany({
+			where: { url: { contains: normalizedWebsite, mode: 'insensitive' } },
+			select: { url: true, organizationId: true },
+		})
+		websiteMatchOrgIds = new Set(
+			candidates
+				.filter((candidate) => normalizeToDomain(candidate.url) === normalizedWebsite)
+				.map((candidate) => candidate.organizationId)
+				.filter((id): id is string => Boolean(id))
+		)
+	}
 
 	/**
-	 * Raw SQL query leveraging Trigram similarity and normalization. We match on fuzzy name similarity OR an
-	 * exact domain-level website match.
+	 * Raw SQL query leveraging Trigram similarity and synonym expansion for fuzzy name matching - there's no
+	 * Prisma query-builder equivalent for trigram similarity, so this part stays raw SQL.
 	 */
-	const results = await prisma.$queryRaw<
-		{
-			id: string
-			name: string
-			slug: string
-			city: string | null
-			state: string | null
-			deleted: boolean
-			published: boolean
-			websiteMatch: boolean
-		}[]
-	>`
+	const nameResults = searchTerm
+		? await prisma.$queryRaw<MatchRow[]>`
     SELECT
       o.id,
       o.name,
@@ -70,57 +108,90 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
       o.deleted,
       o.published,
       l.city,
-      gd.abbrev as state,
-      (
-        ${!!normalizedWebsite} AND
-        EXISTS (
-          SELECT 1 FROM "OrgWebsite" ow
-          WHERE ow."organizationId" = o.id
-          AND regexp_replace(lower(ow.url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite ?? ''}
-        )
-      ) as "websiteMatch"
+      gd.abbrev as state
     FROM "Organization" o
     LEFT JOIN "OrgLocation" l ON l."orgId" = o.id AND l.primary = true
     LEFT JOIN "GovDist" gd ON l."govDistId" = gd.id
     WHERE
-      (
-        (
-          ${!!searchTerm} AND
-          (
-            -- 1. Expanded Term Matching (Synonyms and substrings)
-            lower(public.immutable_unaccent(regexp_replace(o.name, '[^a-zA-Z0-9 ]', '', 'g'))) ILIKE ANY(
-              ${expandedTermsSql}
-            )
-            OR
-            -- 2. Trigram similarity for typos
-            similarity(
-              lower(public.immutable_unaccent(regexp_replace(o.name, '[^a-zA-Z0-9 ]', '', 'g'))),
-              lower(public.immutable_unaccent(regexp_replace(${searchTerm}, '[^a-zA-Z0-9 ]', '', 'g')))
-            ) > 0.3
-          )
-        )
-        OR
-        (
-          ${!!normalizedWebsite} AND
-          EXISTS (
-            SELECT 1 FROM "OrgWebsite" ow
-            WHERE ow."organizationId" = o.id
-            AND regexp_replace(lower(ow.url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite ?? ''}
-          )
-        )
+      -- 1. Expanded Term Matching (Synonyms and substrings)
+      lower(public.immutable_unaccent(regexp_replace(o.name, '[^a-zA-Z0-9 ]', '', 'g'))) ILIKE ANY(
+        ${expandedTermsSql}
       )
+      OR
+      -- 2. Trigram similarity for typos
+      similarity(
+        lower(public.immutable_unaccent(regexp_replace(o.name, '[^a-zA-Z0-9 ]', '', 'g'))),
+        lower(public.immutable_unaccent(regexp_replace(${searchTerm}, '[^a-zA-Z0-9 ]', '', 'g')))
+      ) > 0.3
     ORDER BY
-      CASE WHEN ${!!searchTerm} THEN similarity(o.name, ${searchTerm}) ELSE 0 END DESC
+      similarity(o.name, ${searchTerm}) DESC
     LIMIT 5;
   `
+		: []
 
-	return results.map((r) => ({
+	// If the website matched an organization the name search didn't already surface (different/unrelated
+	// name, same domain), fetch its display info too, so a pure website-only duplicate still gets flagged.
+	const missingIds = [...websiteMatchOrgIds].filter((id) => !nameResults.some((r) => r.id === id))
+	const extraOrgs: MatchRow[] = missingIds.length
+		? (
+				await prisma.organization.findMany({
+					where: { id: { in: missingIds } },
+					select: {
+						id: true,
+						name: true,
+						slug: true,
+						deleted: true,
+						published: true,
+						locations: {
+							where: { primary: true },
+							take: 1,
+							select: { city: true, govDist: { select: { abbrev: true } } },
+						},
+					},
+				})
+			).map((org) => ({
+				id: org.id,
+				name: org.name,
+				slug: org.slug,
+				deleted: org.deleted,
+				published: org.published,
+				city: org.locations[0]?.city ?? null,
+				state: org.locations[0]?.govDist?.abbrev ?? null,
+			}))
+		: []
+
+	const merged = [...nameResults, ...extraOrgs].slice(0, 5)
+
+	// Near-miss website check: only against orgs whose NAME already matched (a strong prior), and only
+	// those that aren't already an exact website match - catches typos like "aclu.or" vs "aclu.org" that a
+	// name match alone wouldn't flag as a website duplicate, without fuzzy-matching every domain in the DB.
+	const nearMissByOrgId = new Map<string, string>()
+	if (normalizedWebsite) {
+		const nameMatchIdsWithoutExactWebsite = nameResults
+			.map((r) => r.id)
+			.filter((id) => !websiteMatchOrgIds.has(id))
+		if (nameMatchIdsWithoutExactWebsite.length > 0) {
+			const candidateWebsites = await prisma.orgWebsite.findMany({
+				where: { organizationId: { in: nameMatchIdsWithoutExactWebsite } },
+				select: { organizationId: true, url: true },
+			})
+			for (const candidate of candidateWebsites) {
+				if (!candidate.organizationId || nearMissByOrgId.has(candidate.organizationId)) continue
+				const candidateDomain = normalizeToDomain(candidate.url)
+				const distance = levenshteinDistance(normalizedWebsite, candidateDomain)
+				if (distance > 0 && distance <= NEAR_MISS_MAX_DISTANCE) {
+					nearMissByOrgId.set(candidate.organizationId, candidateDomain)
+				}
+			}
+		}
+	}
+
+	return merged.map((r) => ({
 		...r,
 		city: r.city ?? 'Remote',
 		state: r.state ?? '',
-		deleted: r.deleted,
-		published: r.published,
-		websiteMatch: r.websiteMatch,
+		websiteMatch: websiteMatchOrgIds.has(r.id),
+		websiteNearMatch: nearMissByOrgId.get(r.id) ?? null,
 	}))
 }
 

--- a/packages/api/router/organization/query.getPotentialMatches.handler.ts
+++ b/packages/api/router/organization/query.getPotentialMatches.handler.ts
@@ -36,12 +36,20 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 			? Prisma.sql`ARRAY[${Prisma.join(uniqueExpandedTerms.map((t) => `%${t.replace(/[^a-zA-Z0-9 ]/g, '')}%`))}]`
 			: Prisma.sql`ARRAY[]::text[]`
 
-	// Normalize website for comparison (strip protocol, www, and trailing slashes)
-	const normalizedWebsite = website?.replace(/^(https?:\/\/)?(www\.)?/, '').replace(/\/$/, '')
+	// Normalize website down to its bare domain (strip protocol, www, and everything from the first
+	// /, ?, or # onward) so "https://www.example.org/donate" and "example.org" count as the same site.
+	const normalizedWebsite = website
+		? website
+				.trim()
+				.toLowerCase()
+				.replace(/^https?:\/\//, '')
+				.replace(/^www\./, '')
+				.split(/[/?#]/)[0]
+		: undefined
 
 	/**
-	 * Raw SQL query leveraging Trigram similarity and normalization. We match on fuzzy name similarity OR exact
-	 * normalized website match.
+	 * Raw SQL query leveraging Trigram similarity and normalization. We match on fuzzy name similarity OR an
+	 * exact domain-level website match.
 	 */
 	const results = await prisma.$queryRaw<
 		{
@@ -52,6 +60,7 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 			state: string | null
 			deleted: boolean
 			published: boolean
+			websiteMatch: boolean
 		}[]
 	>`
     SELECT
@@ -61,7 +70,15 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
       o.deleted,
       o.published,
       l.city,
-      gd.abbrev as state
+      gd.abbrev as state,
+      (
+        ${!!normalizedWebsite} AND
+        EXISTS (
+          SELECT 1 FROM "OrgWebsite" ow
+          WHERE ow."organizationId" = o.id
+          AND regexp_replace(lower(ow.url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite ?? ''}
+        )
+      ) as "websiteMatch"
     FROM "Organization" o
     LEFT JOIN "OrgLocation" l ON l."orgId" = o.id AND l.primary = true
     LEFT JOIN "GovDist" gd ON l."govDistId" = gd.id
@@ -88,7 +105,7 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
           EXISTS (
             SELECT 1 FROM "OrgWebsite" ow
             WHERE ow."organizationId" = o.id
-            AND (ow.url ILIKE ${'%' + (normalizedWebsite ?? '') + '%'} OR REPLACE(REPLACE(REPLACE(ow.url, 'https://', ''), 'http://', ''), 'www.', '') ILIKE ${normalizedWebsite ?? ''})
+            AND regexp_replace(lower(ow.url), '^(https?://)?(www\.)?([^/?#]+).*$', '\3') = ${normalizedWebsite ?? ''}
           )
         )
       )
@@ -103,6 +120,7 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 		state: r.state ?? '',
 		deleted: r.deleted,
 		published: r.published,
+		websiteMatch: r.websiteMatch,
 	}))
 }
 

--- a/packages/api/router/organization/query.getPotentialMatches.handler.ts
+++ b/packages/api/router/organization/query.getPotentialMatches.handler.ts
@@ -35,6 +35,16 @@ const levenshteinDistance = (a: string, b: string) => {
 
 const NEAR_MISS_MAX_DISTANCE = 2
 
+// Splits a normalized domain into its name and TLD (e.g. "aclu.org" -> { name: "aclu", tld: "org" }) on
+// the last dot. Good enough for the simple .com/.org/.net-style TLDs expected here - not meant to handle
+// multi-part TLDs like ".co.uk".
+const splitDomain = (domain: string) => {
+	const lastDot = domain.lastIndexOf('.')
+	return lastDot === -1
+		? { name: domain, tld: '' }
+		: { name: domain.slice(0, lastDot), tld: domain.slice(lastDot + 1) }
+}
+
 type MatchRow = {
 	id: string
 	name: string
@@ -163,10 +173,14 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 	const merged = [...nameResults, ...extraOrgs].slice(0, 5)
 
 	// Near-miss website check: only against orgs whose NAME already matched (a strong prior), and only
-	// those that aren't already an exact website match - catches typos like "aclu.or" vs "aclu.org" that a
-	// name match alone wouldn't flag as a website duplicate, without fuzzy-matching every domain in the DB.
+	// those that aren't already an exact website match. Two independent signals catch two different typo
+	// shapes: edit distance catches a dropped/extra/swapped letter (e.g. "aclu.or" vs "aclu.org"), while
+	// the same-name-different-TLD check catches a wrong-but-valid TLD (e.g. "aclu.com" vs "aclu.org") -
+	// those can differ by 3+ characters, well past the edit-distance threshold, despite being an obvious
+	// mistake once you notice the name part is identical.
 	const nearMissByOrgId = new Map<string, string>()
 	if (normalizedWebsite) {
+		const inputDomain = splitDomain(normalizedWebsite)
 		const nameMatchIdsWithoutExactWebsite = nameResults
 			.map((r) => r.id)
 			.filter((id) => !websiteMatchOrgIds.has(id))
@@ -178,8 +192,13 @@ const getPotentialMatches = async ({ input }: TRPCHandlerParams<TGetPotentialMat
 			for (const candidate of candidateWebsites) {
 				if (!candidate.organizationId || nearMissByOrgId.has(candidate.organizationId)) continue
 				const candidateDomain = normalizeToDomain(candidate.url)
+				const candidateSplit = splitDomain(candidateDomain)
 				const distance = levenshteinDistance(normalizedWebsite, candidateDomain)
-				if (distance > 0 && distance <= NEAR_MISS_MAX_DISTANCE) {
+				const sameNameDifferentTld =
+					inputDomain.name !== '' &&
+					inputDomain.name === candidateSplit.name &&
+					inputDomain.tld !== candidateSplit.tld
+				if ((distance > 0 && distance <= NEAR_MISS_MAX_DISTANCE) || sameNameDifferentTld) {
 					nearMissByOrgId.set(candidate.organizationId, candidateDomain)
 				}
 			}

--- a/packages/api/schemas/create/browserSafe/suggestOrg.ts
+++ b/packages/api/schemas/create/browserSafe/suggestOrg.ts
@@ -2,6 +2,36 @@ import { z } from 'zod'
 
 const nonEmptyString = z.string().trim().min(2)
 
+// Not exhaustive of every IANA TLD - just the ones realistically expected for an org located in the
+// countries this form currently accepts (US, Mexico, Canada), plus common generic TLDs. Catches typos
+// like "aclu.or" (missing the final letter) that `.url()` alone can't detect.
+const ALLOWED_TLDS = new Set([
+	'com',
+	'org',
+	'net',
+	'edu',
+	'gov',
+	'mil',
+	'info',
+	'biz',
+	'co',
+	'io',
+	'app',
+	'me',
+	'us',
+	'mx',
+	'ca',
+])
+
+const hasValidTld = (url: string) => {
+	try {
+		const tld = new URL(url).hostname.split('.').pop()?.toLowerCase()
+		return Boolean(tld && ALLOWED_TLDS.has(tld))
+	} catch {
+		return false
+	}
+}
+
 export const SuggestionSchema = z.object({
 	countryId: nonEmptyString,
 	orgName: nonEmptyString,
@@ -10,7 +40,11 @@ export const SuggestionSchema = z.object({
 		.string({ required_error: 'Organization website is required' })
 		.trim()
 		.min(1, 'Organization website is required')
-		.url('Invalid URL format'),
+		.url('Please enter a valid, complete URL (e.g. https://example.org)')
+		.refine(hasValidTld, {
+			message:
+				"That doesn't look like a valid website address - please double check for typos (e.g. https://example.org)",
+		}),
 	orgAddress: z
 		.object({
 			street1: z.string(),

--- a/packages/api/schemas/create/browserSafe/suggestOrg.ts
+++ b/packages/api/schemas/create/browserSafe/suggestOrg.ts
@@ -6,7 +6,11 @@ export const SuggestionSchema = z.object({
 	countryId: nonEmptyString,
 	orgName: nonEmptyString,
 	orgSlug: nonEmptyString,
-	orgWebsite: z.union([z.literal(''), z.string().trim().url('Invalid URL format')]).optional(),
+	orgWebsite: z
+		.string({ required_error: 'Organization website is required' })
+		.trim()
+		.min(1, 'Organization website is required')
+		.url('Invalid URL format'),
 	orgAddress: z
 		.object({
 			street1: z.string(),

--- a/packages/ui/components/sections/SuggestOrg/index.stories.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.stories.tsx
@@ -26,10 +26,6 @@ type StoryDef = StoryObj<typeof SuggestOrg>
 
 export const Desktop = {} satisfies StoryDef
 
-// Type "Existing Organization" as the org name - shows the non-blocking "similar name" warning,
-// submit stays enabled.
-export const SimilarNameWarning = {} satisfies StoryDef
-
 // Type any website containing "example.org" - shows the hard-blocking "duplicate website" message
 // and disables submit.
 export const DuplicateWebsiteBlocked = {} satisfies StoryDef

--- a/packages/ui/components/sections/SuggestOrg/index.stories.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.stories.tsx
@@ -34,9 +34,9 @@ export const SimilarNameWarning = {} satisfies StoryDef
 // and disables submit.
 export const DuplicateWebsiteBlocked = {} satisfies StoryDef
 
-// Type "Existing Organization" as the name AND a website containing "existingorg2.org" (a typo of
-// existingorg.org, but still a valid TLD) - shows the dismissable "Did you mean existingorg.org?"
-// checkbox; submit stays disabled until it's checked.
+// Type "Existing Organization" as the name AND a website containing either "existingorg2.org" (an
+// edit-distance typo) or "existingorg.com" (same name, wrong-but-valid TLD) - both shapes show the
+// dismissable "Did you mean existingorg.org?" checkbox; submit stays disabled until it's checked.
 export const NearMissWebsiteWarning = {} satisfies StoryDef
 
 // Fill out the form with a valid, non-matching website (e.g. https://brandneworg.org) and submit - the

--- a/packages/ui/components/sections/SuggestOrg/index.stories.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.stories.tsx
@@ -17,6 +17,7 @@ export default {
 			organization.suggestionOptions,
 			organization.createNewSuggestion, // Keep this for the actual submission
 			organization.generateSlug,
+			organization.getPotentialMatches,
 		],
 	},
 } satisfies Meta<typeof SuggestOrg>
@@ -24,3 +25,26 @@ export default {
 type StoryDef = StoryObj<typeof SuggestOrg>
 
 export const Desktop = {} satisfies StoryDef
+
+// Type "Existing Organization" as the org name - shows the non-blocking "similar name" warning,
+// submit stays enabled.
+export const SimilarNameWarning = {} satisfies StoryDef
+
+// Type any website containing "example.org" - shows the hard-blocking "duplicate website" message
+// and disables submit.
+export const DuplicateWebsiteBlocked = {} satisfies StoryDef
+
+// Fill out the form with a non-matching website and submit - the mutation always rejects with
+// CONFLICT, demonstrating the server-side error alert (e.g. for a race-condition duplicate).
+export const SubmitConflictError = {
+	parameters: {
+		msw: [
+			geo.autocompleteFullAddress,
+			geo.geocodeFullAddress,
+			organization.suggestionOptions,
+			organization.createNewSuggestionConflict,
+			organization.generateSlug,
+			organization.getPotentialMatches,
+		],
+	},
+} satisfies StoryDef

--- a/packages/ui/components/sections/SuggestOrg/index.stories.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.stories.tsx
@@ -34,13 +34,14 @@ export const SimilarNameWarning = {} satisfies StoryDef
 // and disables submit.
 export const DuplicateWebsiteBlocked = {} satisfies StoryDef
 
-// Type "Existing Organization" as the name AND a website containing "existingorg.or" (note: missing the
-// final "g") - shows the dismissable "Did you mean existingorg.org?" checkbox; submit stays disabled
-// until it's checked.
+// Type "Existing Organization" as the name AND a website containing "existingorg2.org" (a typo of
+// existingorg.org, but still a valid TLD) - shows the dismissable "Did you mean existingorg.org?"
+// checkbox; submit stays disabled until it's checked.
 export const NearMissWebsiteWarning = {} satisfies StoryDef
 
-// Fill out the form with a non-matching website and submit - the mutation always rejects with
-// CONFLICT, demonstrating the server-side error alert (e.g. for a race-condition duplicate).
+// Fill out the form with a valid, non-matching website (e.g. https://brandneworg.org) and submit - the
+// mutation always rejects with CONFLICT, demonstrating the server-side error alert (e.g. for a
+// race-condition duplicate).
 export const SubmitConflictError = {
 	parameters: {
 		msw: [

--- a/packages/ui/components/sections/SuggestOrg/index.stories.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.stories.tsx
@@ -34,6 +34,11 @@ export const SimilarNameWarning = {} satisfies StoryDef
 // and disables submit.
 export const DuplicateWebsiteBlocked = {} satisfies StoryDef
 
+// Type "Existing Organization" as the name AND a website containing "existingorg.or" (note: missing the
+// final "g") - shows the dismissable "Did you mean existingorg.org?" checkbox; submit stays disabled
+// until it's checked.
+export const NearMissWebsiteWarning = {} satisfies StoryDef
+
 // Fill out the form with a non-matching website and submit - the mutation always rejects with
 // CONFLICT, demonstrating the server-side error alert (e.g. for a race-condition duplicate).
 export const SubmitConflictError = {

--- a/packages/ui/components/sections/SuggestOrg/index.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.tsx
@@ -3,6 +3,7 @@ import {
 	Autocomplete,
 	type AutocompleteItem,
 	Button,
+	Checkbox,
 	createStyles,
 	Divider,
 	Modal,
@@ -93,10 +94,13 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	const { overlay, setOverlay, hasAuth } = authPromptState
 
 	const [submitError, setSubmitError] = useState<string | null>(null)
+	const [submittedOrgName, setSubmittedOrgName] = useState('')
 	const suggestOrgApi = api.organization.createNewSuggestion.useMutation({
 		onSuccess: () => {
 			searchBoxEvent.suggestResourceSubmit(form.values.orgName)
 			setSubmitError(null)
+			setSubmittedOrgName(form.values.orgName)
+			resetFormState()
 			modalHandler.open()
 		},
 		onError: (error) => {
@@ -135,6 +139,7 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	>(null)
 	const [dismissMatches, setDismissMatches] = useState(false)
 	const [generateSlug, setGenerateSlug] = useState(false)
+	const [bypassNearMissWebsite, setBypassNearMissWebsite] = useState(false)
 	const router = useRouter()
 
 	const countrySelected = Boolean(form.values.countryId)
@@ -237,6 +242,17 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 		[potentialMatches]
 	)
 
+	// Suggested domain when the typed website is a near-miss (e.g. a typo) of an org whose name already
+	// matched - a softer signal than an exact match, so it's dismissable rather than a hard block.
+	const websiteNearMatch = useMemo(
+		() => potentialMatches?.find((match) => match.websiteNearMatch)?.websiteNearMatch ?? null,
+		[potentialMatches]
+	)
+
+	useEffect(() => {
+		setBypassNearMissWebsite(false)
+	}, [orgWebsite])
+
 	// Name similarity is informational only - it never blocks slug generation or submission.
 	// Only a website/domain match (below) is treated as an actual duplicate.
 	useEffect(() => {
@@ -295,7 +311,9 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 		[setPlaceId]
 	)
 
-	const handleDismiss = useCallback(() => {
+	// Clears every piece of state that drives the duplicate-detection warnings, so a successful
+	// submission doesn't leave a stale "this is a duplicate" message on screen for the next entry.
+	const resetFormState = useCallback(() => {
 		form.setValues({
 			communityFocus: [],
 			countryId: '',
@@ -307,8 +325,13 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 		})
 		setSearchLocation('')
 		setOrgNameInput('')
+		setOrgWebsite(undefined)
+		setBypassNearMissWebsite(false)
+	}, [form, setBypassNearMissWebsite, setOrgNameInput, setOrgWebsite, setSearchLocation])
+
+	const handleDismiss = useCallback(() => {
 		modalHandler.close()
-	}, [form, modalHandler, setOrgNameInput, setSearchLocation])
+	}, [modalHandler])
 
 	if (!mounted || loading) {
 		return null
@@ -357,7 +380,6 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 							onItemSubmit={(item: OrgAutocompleteItem) => handleInspectMatch(item.match)}
 							filter={() => true}
 						/>
-
 						{isExactMatch && (
 							<Text size='sm' color='red' mt='sm'>
 								An organization with a similar name already exists. This can happen legitimately (e.g.
@@ -373,7 +395,12 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 							withAsterisk
 							disabled={!countrySelected}
 							{...form.getInputProps('orgWebsite')}
-							onBlur={handleWebsiteBlur}
+							onBlur={(e) => {
+								// form.getInputProps' own onBlur runs the field's validation (shows the error
+								// text below) - it must not be replaced by our own onBlur, only supplemented.
+								form.getInputProps('orgWebsite').onBlur(e)
+								handleWebsiteBlur(e)
+							}}
 						/>
 
 						{isWebsiteMatch && (
@@ -381,6 +408,18 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 								This website is already associated with an existing organization in our system. If you believe
 								this is an error, please double check the URL you entered.
 							</Text>
+						)}
+
+						{!isWebsiteMatch && websiteNearMatch && (
+							<Checkbox
+								mt='sm'
+								label={`Did you mean ${websiteNearMatch}? Check this box if the website you entered is correct and this is a different organization.`}
+								checked={bypassNearMissWebsite}
+								onChange={(event) => setBypassNearMissWebsite(event.currentTarget.checked)}
+								styles={(theme) => ({
+									label: { color: theme.colors.red?.[7] ?? 'red', fontWeight: 500 },
+								})}
+							/>
 						)}
 					</Stack>
 
@@ -416,7 +455,8 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 									!form.isValid() ||
 									Object.keys(form.errors).length !== 0 ||
 									isMatchingPending ||
-									isWebsiteMatch
+									isWebsiteMatch ||
+									(Boolean(websiteNearMatch) && !bypassNearMissWebsite)
 								}
 								type='submit'
 							>
@@ -433,7 +473,7 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 				>
 					<Stack align='center' spacing={16}>
 						<Title order={1}>🎉</Title>
-						<Title order={2}>{t('modal.thank-you', { org: form.values.orgName })}</Title>
+						<Title order={2}>{t('modal.thank-you', { org: submittedOrgName })}</Title>
 						<Text variant={variants.Text.darkGray} align='center'>
 							{t('modal.thank-you-sub')}
 						</Text>

--- a/packages/ui/components/sections/SuggestOrg/index.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.tsx
@@ -203,30 +203,6 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	const isMatchingPending = isSearchingMatches || orgNameInput !== debouncedOrgName
 	const currentOrgSlug = form.values.orgSlug
 
-	const isExactMatch = useMemo(() => {
-		if (!potentialMatches || potentialMatches.length === 0) return false
-
-		const cleanForStrictMatch = (str: string) => {
-			return str
-				.toLowerCase()
-				.trim()
-				.replace(/^(the|a|an)\s+/i, '')
-				.replace(/[^a-z0-9]/g, '')
-		}
-
-		const normalizedInput = cleanForStrictMatch(orgNameInput)
-		if (!normalizedInput) return false
-
-		return potentialMatches.some((match) => {
-			const normalizedMatch = cleanForStrictMatch(match.name)
-			return (
-				normalizedMatch === normalizedInput ||
-				normalizedMatch.includes(normalizedInput) ||
-				normalizedInput.includes(normalizedMatch)
-			)
-		})
-	}, [potentialMatches, orgNameInput])
-
 	const orgAutocompleteOptions = useMemo(
 		() =>
 			potentialMatches?.map((match) => ({
@@ -380,13 +356,6 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 							onItemSubmit={(item: OrgAutocompleteItem) => handleInspectMatch(item.match)}
 							filter={() => true}
 						/>
-						{isExactMatch && (
-							<Text size='sm' color='red' mt='sm'>
-								An organization with a similar name already exists. This can happen legitimately (e.g.
-								different chapters, or unrelated organizations that happen to share a name) - you can continue
-								if you're sure this is a different organization.
-							</Text>
-						)}
 
 						<TextInput
 							label={t('form.org-website')}

--- a/packages/ui/components/sections/SuggestOrg/index.tsx
+++ b/packages/ui/components/sections/SuggestOrg/index.tsx
@@ -1,8 +1,8 @@
 import {
+	Alert,
 	Autocomplete,
 	type AutocompleteItem,
 	Button,
-	Checkbox,
 	createStyles,
 	Divider,
 	Modal,
@@ -92,10 +92,15 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	const [modalOpen, modalHandler] = useDisclosure(false)
 	const { overlay, setOverlay, hasAuth } = authPromptState
 
+	const [submitError, setSubmitError] = useState<string | null>(null)
 	const suggestOrgApi = api.organization.createNewSuggestion.useMutation({
 		onSuccess: () => {
 			searchBoxEvent.suggestResourceSubmit(form.values.orgName)
+			setSubmitError(null)
 			modalHandler.open()
+		},
+		onError: (error) => {
+			setSubmitError(error.message)
 		},
 	})
 
@@ -130,7 +135,6 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	>(null)
 	const [dismissMatches, setDismissMatches] = useState(false)
 	const [generateSlug, setGenerateSlug] = useState(false)
-	const [bypassExactMatch, setBypassExactMatch] = useState(false)
 	const router = useRouter()
 
 	const countrySelected = Boolean(form.values.countryId)
@@ -228,32 +232,18 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 		[potentialMatches]
 	)
 
-	useEffect(() => {
-		setBypassExactMatch(false)
-	}, [orgNameInput])
+	const isWebsiteMatch = useMemo(
+		() => Boolean(potentialMatches?.some((match) => match.websiteMatch)),
+		[potentialMatches]
+	)
 
+	// Name similarity is informational only - it never blocks slug generation or submission.
+	// Only a website/domain match (below) is treated as an actual duplicate.
 	useEffect(() => {
-		if (mounted && !isExactMatch && !generateSlug && debouncedOrgName.trim() !== '') {
+		if (mounted && !generateSlug && debouncedOrgName.trim() !== '') {
 			setGenerateSlug(true)
 		}
-
-		if (mounted && isExactMatch && !bypassExactMatch) {
-			if (currentOrgSlug !== '') {
-				form.setFieldValue('orgSlug', '')
-			}
-			if (generateSlug) {
-				setGenerateSlug(false)
-			}
-		}
-	}, [
-		mounted,
-		isExactMatch,
-		generateSlug,
-		currentOrgSlug,
-		debouncedOrgName,
-		bypassExactMatch,
-		form.setFieldValue,
-	])
+	}, [mounted, generateSlug, debouncedOrgName])
 
 	const handleInspectMatch = (match: ApiOutput['organization']['getPotentialMatches'][number]) =>
 		setInspectMatch(match)
@@ -325,7 +315,12 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 	}
 	return (
 		<SuggestionFormProvider form={form}>
-			<form onSubmit={form.onSubmit(() => suggestOrgApi.mutate(form.values))}>
+			<form
+				onSubmit={form.onSubmit(() => {
+					setSubmitError(null)
+					suggestOrgApi.mutate(form.values)
+				})}
+			>
 				<Stack spacing={40} pb={40}>
 					<Stack spacing={24}>
 						<Title order={1}>{t('body.suggest-org')}</Title>
@@ -364,24 +359,29 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 						/>
 
 						{isExactMatch && (
-							<Checkbox
-								mt='sm'
-								label='This is a different organization with a similar name, let me submit anyway.'
-								checked={bypassExactMatch}
-								onChange={(event) => setBypassExactMatch(event.currentTarget.checked)}
-								styles={(theme) => ({
-									label: { color: theme.colors.red?.[7] ?? 'red', fontWeight: 500 },
-								})}
-							/>
+							<Text size='sm' color='red' mt='sm'>
+								An organization with a similar name already exists. This can happen legitimately (e.g.
+								different chapters, or unrelated organizations that happen to share a name) - you can continue
+								if you're sure this is a different organization.
+							</Text>
 						)}
 
 						<TextInput
 							label={t('form.org-website')}
 							placeholder={t('form.placeholder-website')}
+							required
+							withAsterisk
 							disabled={!countrySelected}
 							{...form.getInputProps('orgWebsite')}
 							onBlur={handleWebsiteBlur}
 						/>
+
+						{isWebsiteMatch && (
+							<Text size='sm' color='red'>
+								This website is already associated with an existing organization in our system. If you believe
+								this is an error, please double check the URL you entered.
+							</Text>
+						)}
 					</Stack>
 
 					<Divider />
@@ -403,6 +403,11 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 						<ServiceTypes disabled={!countrySelected} serviceTypes={formOptions?.serviceTypes ?? []} />
 						<Communities disabled={!countrySelected} communities={formOptions?.communities ?? []} />
 						<Divider />
+						{submitError && (
+							<Alert icon={<Icon icon='carbon:warning' />} title='Unable to submit' color='red'>
+								{submitError}
+							</Alert>
+						)}
 						<Stack spacing={16} align='center'>
 							<Button
 								w='fit-content'
@@ -411,7 +416,7 @@ export const SuggestOrg = ({ authPromptState }: SuggestOrgProps) => {
 									!form.isValid() ||
 									Object.keys(form.errors).length !== 0 ||
 									isMatchingPending ||
-									(isExactMatch && !bypassExactMatch)
+									isWebsiteMatch
 								}
 								type='submit'
 							>

--- a/packages/ui/mockData/organization.ts
+++ b/packages/ui/mockData/organization.ts
@@ -77,6 +77,54 @@ export const organization = {
 		type: 'mutation',
 		response: { id: 'sugg_LKSDJFIOW156AWER15' },
 	}),
+	// Always rejects, to demo the "duplicate website" error the form shows when the server-side check fires
+	// (e.g. a race condition, or the client-side domain check was bypassed).
+	createNewSuggestionConflict: getTRPCMock({
+		path: ['organization', 'createNewSuggestion'],
+		type: 'mutation',
+		error: {
+			code: 'CONFLICT',
+			message: 'This website is already associated with an existing organization in our system.',
+		},
+	}),
+	// Flags "Existing Organization" as a name match (soft warning, non-blocking) and any website containing
+	// "example.org" as a domain match (hard block) - used to demo the SuggestOrg duplicate-detection UI.
+	getPotentialMatches: getTRPCMock({
+		path: ['organization', 'getPotentialMatches'],
+		response: (input): ApiOutput['organization']['getPotentialMatches'] => {
+			const matches: ApiOutput['organization']['getPotentialMatches'] = []
+			const name = input.name?.trim().toLowerCase() ?? ''
+			const website = input.website?.trim().toLowerCase() ?? ''
+
+			if (name.includes('existing organization')) {
+				matches.push({
+					id: 'orgn_MOCKEDNAMEMATCH00001',
+					name: 'Existing Organization',
+					slug: 'existing-org',
+					city: 'Springfield',
+					state: 'IL',
+					deleted: false,
+					published: true,
+					websiteMatch: false,
+				})
+			}
+
+			if (website.includes('example.org')) {
+				matches.push({
+					id: 'orgn_MOCKEDSITEMATCH00001',
+					name: 'A Totally Different Org',
+					slug: 'a-totally-different-org',
+					city: 'Denver',
+					state: 'CO',
+					deleted: false,
+					published: true,
+					websiteMatch: true,
+				})
+			}
+
+			return matches
+		},
+	}),
 	generateSlug: getTRPCMock({
 		path: ['organization', 'generateSlug'],
 		response: 'this-is-a-generated-slug',
@@ -169,4 +217,7 @@ export const organization = {
 			id: 'atts_NEW0ID',
 		}),
 	}),
-} satisfies MockHandlerObject<'organization'> & { searchDistanceLongTitle: HttpHandler }
+} satisfies MockHandlerObject<'organization'> & {
+	searchDistanceLongTitle: HttpHandler
+	createNewSuggestionConflict: HttpHandler
+}

--- a/packages/ui/mockData/organization.ts
+++ b/packages/ui/mockData/organization.ts
@@ -87,8 +87,9 @@ export const organization = {
 			message: 'This website is already associated with an existing organization in our system.',
 		},
 	}),
-	// Flags "Existing Organization" as a name match (soft warning, non-blocking) and any website containing
-	// "example.org" as a domain match (hard block) - used to demo the SuggestOrg duplicate-detection UI.
+	// Flags "Existing Organization" as a name match (soft warning, non-blocking), any website containing
+	// "example.org" as a domain match (hard block), and "existingorg.or" as a near-miss of that same org's
+	// domain (dismissable checkbox) - used to demo the SuggestOrg duplicate-detection UI.
 	getPotentialMatches: getTRPCMock({
 		path: ['organization', 'getPotentialMatches'],
 		response: (input): ApiOutput['organization']['getPotentialMatches'] => {
@@ -106,6 +107,7 @@ export const organization = {
 					deleted: false,
 					published: true,
 					websiteMatch: false,
+					websiteNearMatch: website.includes('existingorg.or') ? 'existingorg.org' : null,
 				})
 			}
 
@@ -119,6 +121,7 @@ export const organization = {
 					deleted: false,
 					published: true,
 					websiteMatch: true,
+					websiteNearMatch: null,
 				})
 			}
 

--- a/packages/ui/mockData/organization.ts
+++ b/packages/ui/mockData/organization.ts
@@ -88,8 +88,10 @@ export const organization = {
 		},
 	}),
 	// Flags "Existing Organization" as a name match (soft warning, non-blocking), any website containing
-	// "example.org" as a domain match (hard block), and "existingorg.or" as a near-miss of that same org's
-	// domain (dismissable checkbox) - used to demo the SuggestOrg duplicate-detection UI.
+	// "example.org" as a domain match (hard block), and "existingorg2.org" as a near-miss (typo, but still
+	// a valid TLD) of that same org's domain (dismissable checkbox) - used to demo the SuggestOrg
+	// duplicate-detection UI. Note: the near-miss trigger must have a *valid* TLD, or TLD validation in the
+	// form schema rejects it outright before the near-miss check ever gets a chance to run.
 	getPotentialMatches: getTRPCMock({
 		path: ['organization', 'getPotentialMatches'],
 		response: (input): ApiOutput['organization']['getPotentialMatches'] => {
@@ -107,7 +109,7 @@ export const organization = {
 					deleted: false,
 					published: true,
 					websiteMatch: false,
-					websiteNearMatch: website.includes('existingorg.or') ? 'existingorg.org' : null,
+					websiteNearMatch: website.includes('existingorg2.org') ? 'existingorg.org' : null,
 				})
 			}
 

--- a/packages/ui/mockData/organization.ts
+++ b/packages/ui/mockData/organization.ts
@@ -88,16 +88,19 @@ export const organization = {
 		},
 	}),
 	// Flags "Existing Organization" as a name match (soft warning, non-blocking), any website containing
-	// "example.org" as a domain match (hard block), and "existingorg2.org" as a near-miss (typo, but still
-	// a valid TLD) of that same org's domain (dismissable checkbox) - used to demo the SuggestOrg
-	// duplicate-detection UI. Note: the near-miss trigger must have a *valid* TLD, or TLD validation in the
-	// form schema rejects it outright before the near-miss check ever gets a chance to run.
+	// "example.org" as a domain match (hard block), and either "existingorg2.org" (edit-distance typo) or
+	// "existingorg.com" / "existingorg.net" (same name, wrong-but-valid TLD) as a near-miss of that same
+	// org's domain (dismissable checkbox) - used to demo the SuggestOrg duplicate-detection UI. Note: near-
+	// miss triggers must have a *valid* TLD, or TLD validation in the form schema rejects them outright
+	// before the near-miss check ever gets a chance to run.
 	getPotentialMatches: getTRPCMock({
 		path: ['organization', 'getPotentialMatches'],
 		response: (input): ApiOutput['organization']['getPotentialMatches'] => {
 			const matches: ApiOutput['organization']['getPotentialMatches'] = []
 			const name = input.name?.trim().toLowerCase() ?? ''
 			const website = input.website?.trim().toLowerCase() ?? ''
+			const isNearMissTypo = website.includes('existingorg2.org')
+			const isNearMissWrongTld = website.includes('existingorg.com') || website.includes('existingorg.net')
 
 			if (name.includes('existing organization')) {
 				matches.push({
@@ -109,7 +112,7 @@ export const organization = {
 					deleted: false,
 					published: true,
 					websiteMatch: false,
-					websiteNearMatch: website.includes('existingorg2.org') ? 'existingorg.org' : null,
+					websiteNearMatch: isNearMissTypo || isNearMissWrongTld ? 'existingorg.org' : null,
 				})
 			}
 


### PR DESCRIPTION
# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

The "Suggest an Organization" form's duplicate-detection logic has several problems:

- The organization website field is optional, and duplicate websites are never checked at all — someone can suggest an org whose URL already belongs to an existing organization with zero warning.
- Duplicate detection is driven primarily by fuzzy **name** matching. This causes two opposite failures: unrelated organizations that happen to share a name get flagged/blocked, while a genuine duplicate submitted under a different name or abbreviation (e.g. "ACLU" vs "American Civil Liberties Union") sails through undetected.
- The "this is a different organization, let me submit anyway" checkbox is broken: checking it never actually unblocks the submit button, because the effect that's supposed to resume slug generation after the checkbox is checked never fires. Anyone who hits this warning is permanently stuck and cannot submit.
- The website field accepts malformed or nonsense values (`www.test.com` with no scheme, `aclu.or` with a non-existent TLD) with no clear, actionable error message.
- The website-matching SQL used an unanchored substring check (`ILIKE '%...%'`), which could false-positive on unrelated domains that merely contain the same substring.
- Once a duplicate warning was shown, its underlying state was never cleared — including on a *successful* submission — so a stale "this website already exists" message could persist on screen even after a valid org was created.
- Storybook (this repo's primary manual-testing surface, since there's no separate test runner) has no mock at all for the `getPotentialMatches` query, so none of this logic — old or new — could be exercised or visually verified.

## What is the new behavior?

**Website requirements**
- **Website is now required**, enforced on both the client-side Zod schema and the server-side tRPC input schema, with a clear validation message ("Please enter a valid, complete URL (e.g. https://example.org)").
- **TLD validation**: the website's top-level domain is checked against a curated allowlist (generic TLDs plus TLDs for the countries this form currently accepts — US, Mexico, Canada). Catches typos like `aclu.or` (missing the final letter) that basic URL-format validation alone can't detect, with a friendly, actionable error message.
- Fixed a wiring bug where the website field's custom `onBlur` handler was silently overwriting Mantine's own validation `onBlur` (from `form.getInputProps`), meaning format/required errors never actually rendered under the field regardless of what was typed.

**Duplicate detection — now domain-based, not name-based (per product decision)**
- The website is normalized down to its bare domain (protocol, `www.`, and everything after the first `/`, `?`, or `#` stripped) and compared for an **exact** match — both in the live "while typing" check and, as defense-in-depth, again at submission time inside the transaction, so a race condition or a bypassed client check still gets rejected server-side with a `CONFLICT` error.
- **An exact domain match is a hard block with no override.** The submit button stays disabled and an inline message explains why.
- The domain-matching logic was rewritten to use Prisma's standard query builder (a `contains` pre-filter) plus an exact comparison in plain JavaScript, replacing an earlier raw-SQL `regexp_replace`/backreference approach that proved fragile in practice — it caused both a Postgres syntax error (`42601`) and, more seriously, a **silent false negative that let a real duplicate organization get created** during testing. The new approach is easier to reason about and doesn't depend on SQL regex-engine backreference edge cases.
- **Near-miss domain warning**: for organizations whose *name* already fuzzy-matched, their domain is compared to the typed website via Levenshtein edit distance. A 1–2 character difference (e.g. `aclu.or` vs `aclu.org`) surfaces a dismissable "Did you mean `aclu.org`?" checkbox that blocks submission until explicitly confirmed — a compound signal (name + near-miss URL) treated more strictly than either alone, without fuzzy-matching every domain in the database.
- **Name similarity is now purely informational.** It surfaces as a non-blocking warning ("An organization with a similar name already exists...") and never gates submission — this reflects that name collisions between genuinely distinct organizations (different chapters, abbreviations, coincidental overlap) are common and shouldn't be treated as blocking duplicates.

**Other fixes**
- **Fixed the slug-generation deadlock.** Since name matches no longer block anything, the entire `bypassExactMatch` checkbox/gating mechanism (and the bug where checking it never actually re-enabled the submit button) has been removed. Slug generation now depends only on whether an org name has been typed.
- **Added a submit-time error alert** so a server-rejected submission (e.g. the `CONFLICT` from the domain duplicate check) surfaces a clear, visible message instead of failing silently.
- **Fixed stale-warning persistence**: all duplicate-detection state (including the website value driving the live match query, and the near-miss checkbox) is now reset the moment a submission succeeds, not just when the success modal's "Dismiss" button is later clicked. The success modal's "Thank you for submitting X!" text now uses a value captured at submit time so it still displays correctly even though the form resets immediately.
- **Storybook coverage added:** a `getPotentialMatches` mock (previously entirely missing) plus new story variants — `SimilarNameWarning`, `DuplicateWebsiteBlocked`, `NearMissWebsiteWarning`, and `SubmitConflictError` — so all duplicate-detection paths can be manually verified going forward.

Files changed:
- `packages/api/schemas/create/browserSafe/suggestOrg.ts`
- `packages/api/router/organization/mutation.createNewSuggestion.schema.ts`
- `packages/api/router/organization/mutation.createNewSuggestion.handler.ts`
- `packages/api/router/organization/query.getPotentialMatches.handler.ts`
- `packages/ui/components/sections/SuggestOrg/index.tsx`
- `packages/ui/components/sections/SuggestOrg/index.stories.tsx`
- `packages/ui/mockData/organization.ts`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Not breaking for end users. Note for API consumers: `orgWebsite` is now a **required, TLD-validated** field on the `organization.createNewSuggestion` mutation input (previously optional) — any direct API caller that omitted it, or passed a malformed/non-existent-TLD URL, will now fail input validation.

## Other information

**Product decisions this implements** (confirmed with product, see PR discussion/thread for full context):
1. Same name, different website → non-blocking warning only (avoids blocking legitimate chapters/affiliates or unrelated orgs with coincidentally shared names).
2. Different name, same website → hard block, no override.
3. Name typos/abbreviations → no special handling needed; solved by de-prioritizing name as the blocking signal.
4. Website match strictness → domain-level only, disregarding path/query (e.g. `example.org` and `example.org/donate` are treated as the same organization).
5. Near-miss domain typos (e.g. `aclu.or`, discovered during manual QA, not part of the original four decisions) → closed via TLD validation (catches invalid TLDs outright) plus a dismissable near-miss warning scoped to orgs whose name already matched (catches typos that still land on a valid TLD).

**Known limitation:** the TLD allowlist is a curated list of common/expected TLDs, not the full IANA registry — an org with a legitimate but obscure TLD not on the list would need that list updated. No third-party TLD-validation package or Postgres `fuzzystrmatch` extension was available in the repo, so this was implemented with a hardcoded list and a hand-rolled Levenshtein function respectively, to avoid adding new dependencies/migrations for this fix.

**How to verify in Storybook:** open `Sections/Suggest an Organization`.
- `Desktop` — baseline, no matches.
- `SimilarNameWarning` — type "Existing Organization" as the org name to see the non-blocking warning; submit stays enabled.
- `DuplicateWebsiteBlocked` — type a website containing "example.org" to see the hard block and disabled submit button.
- `NearMissWebsiteWarning` — type "Existing Organization" as the name and a website containing "existingorg.or" to see the dismissable "Did you mean existingorg.org?" checkbox; submit stays disabled until checked.
- `SubmitConflictError` — fill out the form with a non-matching website and submit to see the server-side error alert.

**Manual QA performed locally** against a real database, which surfaced and led to fixing: a Postgres raw-SQL syntax error, a silent duplicate-detection false negative (a real duplicate org was created and then removed), the `onBlur` handler-overwrite bug, and the stale-warning-after-success bug described above.

**Non-Technical explanation**
* The website/URL field is now required when someone suggests an organization — it can no longer be left blank.
* We now check whether the submitted website already belongs to an organization we have — if it does, the submission is blocked with a clear explanation.
* We catch common website typos (missing "http://", or an ending like ".or" instead of ".org") and show a helpful message instead of silently failing.
* If a submitted website looks like a likely typo of an existing organization's site (e.g. "aclu2.org" instead of "aclu.org"), we show a "did you mean...?" warning that the person has to acknowledge before continuing.
* If the organization name looks similar to one we already have, we now just show a friendly heads-up rather than blocking submission — since many real organizations legitimately share or overlap in name (different chapters, abbreviations, etc.).