### PR TITLE
bugfix: make city hidden in search and profile for non-remote/nationwide org

### DIFF
--- a/packages/api/router/organization/query.searchDistance.handler.ts
+++ b/packages/api/router/organization/query.searchDistance.handler.ts
@@ -294,32 +294,35 @@ const prismaDistSearchDetails = async (input: TSearchDistanceSchema & { resultId
 			})
 		)
 
-		locations.forEach(({ services: locationServices, city, ...coords }) => {
-			city &&
-				cities.push({
-					city,
-					dist: getDistance(
-						{ latitude, longitude },
-						{ latitude: coords.latitude ?? 0, longitude: coords.longitude ?? 0 },
-						1000
-					),
-				})
-			locationServices.forEach(({ service }) =>
-				service.services.forEach(({ tag, service: innerService }) => {
-					const { id, tsKey, tsNs, primaryCategory } = tag
-					servIds.add(id)
-					serviceCategoryMap.set(primaryCategory.id, primaryCategory)
-					serviceTagMap.set(id, { id, tsKey, tsNs })
-					innerService.attributes.forEach(({ attribute }) => {
-						const { categories, ...attrib } = attribute
-						attribIds.add(attrib.id)
-						categories.forEach(({ category }) =>
-							attributeMap.set(`${attrib.id}${category.tag}`, { category, ...attrib })
-						)
+		locations.forEach(
+			({ services: locationServices, city, addressVisibility: locationVisibility, ...coords }) => {
+				city &&
+					locationVisibility !== 'HIDDEN' &&
+					cities.push({
+						city,
+						dist: getDistance(
+							{ latitude, longitude },
+							{ latitude: coords.latitude ?? 0, longitude: coords.longitude ?? 0 },
+							1000
+						),
 					})
-				})
-			)
-		})
+				locationServices.forEach(({ service }) =>
+					service.services.forEach(({ tag, service: innerService }) => {
+						const { id, tsKey, tsNs, primaryCategory } = tag
+						servIds.add(id)
+						serviceCategoryMap.set(primaryCategory.id, primaryCategory)
+						serviceTagMap.set(id, { id, tsKey, tsNs })
+						innerService.attributes.forEach(({ attribute }) => {
+							const { categories, ...attrib } = attribute
+							attribIds.add(attrib.id)
+							categories.forEach(({ category }) =>
+								attributeMap.set(`${attrib.id}${category.tag}`, { category, ...attrib })
+							)
+						})
+					})
+				)
+			}
+		)
 		attributes.forEach(({ attribute }) => {
 			const { categories, ...attrib } = attribute
 			attribIds.add(attrib.id)
@@ -350,10 +353,7 @@ const prismaDistSearchDetails = async (input: TSearchDistanceSchema & { resultId
 
 		// If there is exactly one location, use its visibility setting.
 		// Otherwise (multiple locations), leave undefined to keep current logic (show list).
-		const addressVisibility =
-			locations.length === 1
-				? (locations[0] as unknown as { addressVisibility: 'FULL' | 'PARTIAL' | 'HIDDEN' }).addressVisibility
-				: undefined
+		const addressVisibility = locations.length === 1 ? locations[0]?.addressVisibility : undefined
 
 		return {
 			...rest,

--- a/packages/api/router/organization/query.searchDistanceAdv.handler.ts
+++ b/packages/api/router/organization/query.searchDistanceAdv.handler.ts
@@ -204,29 +204,32 @@ const prismaDistSearchDetails = async (input: { resultIds: string[]; lat: number
 			})
 		)
 
-		locations.forEach(({ services: locationServices, city, ...coords }) => {
-			city &&
-				cities.push({
-					city,
-					dist: getDistance(
-						{ latitude, longitude },
-						{ latitude: coords.latitude ?? 0, longitude: coords.longitude ?? 0 },
-						1000
-					),
-				})
-			locationServices.forEach(({ service }) =>
-				service.services.forEach(({ tag, service: innerService }) => {
-					const { primaryCategory } = tag
-					serviceCategoryMap.set(primaryCategory.id, primaryCategory)
-					innerService.attributes.forEach(({ attribute }) => {
-						const { categories, ...attrib } = attribute
-						categories.forEach(({ category }) =>
-							attributeMap.set(`${attrib.id}${category.tag}`, { category, ...attrib })
-						)
+		locations.forEach(
+			({ services: locationServices, city, addressVisibility: locationVisibility, ...coords }) => {
+				city &&
+					locationVisibility !== 'HIDDEN' &&
+					cities.push({
+						city,
+						dist: getDistance(
+							{ latitude, longitude },
+							{ latitude: coords.latitude ?? 0, longitude: coords.longitude ?? 0 },
+							1000
+						),
 					})
-				})
-			)
-		})
+				locationServices.forEach(({ service }) =>
+					service.services.forEach(({ tag, service: innerService }) => {
+						const { primaryCategory } = tag
+						serviceCategoryMap.set(primaryCategory.id, primaryCategory)
+						innerService.attributes.forEach(({ attribute }) => {
+							const { categories, ...attrib } = attribute
+							categories.forEach(({ category }) =>
+								attributeMap.set(`${attrib.id}${category.tag}`, { category, ...attrib })
+							)
+						})
+					})
+				)
+			}
+		)
 		attributes.forEach(({ attribute }) => {
 			const { categories, ...attrib } = attribute
 			categories.forEach(({ category }) =>
@@ -251,10 +254,7 @@ const prismaDistSearchDetails = async (input: { resultIds: string[]; lat: number
 			),
 		]
 
-		const addressVisibility =
-			locations.length === 1
-				? (locations[0] as unknown as { addressVisibility: 'FULL' | 'PARTIAL' | 'HIDDEN' }).addressVisibility
-				: undefined
+		const addressVisibility = locations.length === 1 ? locations[0]?.addressVisibility : undefined
 
 		return {
 			...rest,

--- a/packages/api/schemas/selects/org.ts
+++ b/packages/api/schemas/selects/org.ts
@@ -413,6 +413,7 @@ export const orgSearchSelect = {
 			city: true,
 			latitude: true,
 			longitude: true,
+			addressVisibility: true,
 			services: {
 				select: {
 					service: selectServ,


### PR DESCRIPTION
Fix search results displaying hidden location addresses

<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the search results page, an organization's city is displayed even when its location's address visibility is set to "Hide address" — this is inconsistent with the organization's own profile page, which correctly hides the address in that case. This affects both single-location organizations (the city should show no location text at all) and multi-location organizations (a hidden location's city should be excluded from the list of cities shown, while other visible locations still display correctly).

Root cause: the Prisma query used for search results never selected the `addressVisibility` field on locations, so an existing check meant to hide the city for `HIDDEN` locations always evaluated against `undefined` and never triggered. The multi-location case additionally had no per-location visibility filtering at all.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `addressVisibility` to the location select used by search (`orgSearchSelect`), so the field is actually fetched.
- Search results now correctly hide a location's city when its address visibility is `HIDDEN`, for both single-location and multi-location organizations — `FULL` and `PARTIAL` visibility are unaffected and continue to display the city as before.
- Removed an unsafe type cast that had been masking the missing field.
- Applied identically to both search handlers (`query.searchDistance.handler.ts` and `query.searchDistanceAdv.handler.ts`), which share duplicated logic.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Verified directly against real data in the local database across all affected scenarios: no locations, single location at each visibility level (FULL/PARTIAL/HIDDEN), and a multi-location organization with a mix of visibility settings (confirmed the hidden location's city is excluded while the others still display). The organization profile page was not touched and continues to behave as before — no code changes there.
