### PR TITLE
feat: Fix org edit page performance and data-integrity bugs

### DIFF
--- a/apps/app/src/pages/org/[slug]/edit.tsx
+++ b/apps/app/src/pages/org/[slug]/edit.tsx
@@ -92,6 +92,23 @@ const OrganizationPage: NextPageWithOptions<InferGetServerSidePropsType<typeof g
 		},
 	})
 
+	// `BadgeEdit` lives in the shared UI package and runs on its own tRPC client/QueryClient, so
+	// it has no way to update this page's `forOrgPageEdits` cache after a save. It calls this back
+	// with the freshly-saved badge selection so we can patch our own cache directly, the same way
+	// `updateBasic` above does for name/description.
+	const handleBadgesChange = (
+		badgeType: 'organization-leadership' | 'service-focus',
+		newAttributes: NonNullable<typeof data>['attributes']
+	) => {
+		apiUtils.organization.forOrgPageEdits.setData({ slug: pageSlug }, (oldData) => {
+			if (!oldData) return oldData
+			const otherAttributes = oldData.attributes.filter(
+				({ attribute }) => !attribute.categories.some(({ category }) => category.tag === badgeType)
+			)
+			return { ...oldData, attributes: [...otherAttributes, ...newAttributes] }
+		})
+	}
+
 	const formMethods = useForm<FormSchema>({
 		// Use defaultValues for initialization. We will populate the form via useEffect.
 		defaultValues: {
@@ -153,6 +170,7 @@ const OrganizationPage: NextPageWithOptions<InferGetServerSidePropsType<typeof g
 								isClaimed,
 							}}
 							edit
+							onBadgesChange={handleBadgesChange}
 						/>
 						{/* eslint-disable-next-line i18next/no-literal-string */}
 						<LocationDrawer>Create new Location</LocationDrawer>

--- a/packages/api/router/orgEmail/mutation.update.handler.ts
+++ b/packages/api/router/orgEmail/mutation.update.handler.ts
@@ -1,4 +1,4 @@
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import { generateNestedFreeTextUpsert, getAuditedClient } from '@weareinreach/db'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
@@ -40,14 +40,19 @@ const update = async ({ ctx, input }: TRPCHandlerParams<TUpdateSchema, 'protecte
 			where: { id: orgId },
 			select: { slug: true },
 		})
-		const crowdin = await upsertSingleKey({
-			isDatabaseString: true,
+		const existing = await prisma.orgEmail.findUnique({
+			where: { id },
+			select: { description: { select: { tsKey: { select: { text: true, crowdinId: true } } } } },
+		})
+		const crowdinId = await syncDatabaseStringIfChanged({
 			key: updateDescriptionText.upsert.create.tsKey.create.key,
-			text: updateDescriptionText.upsert.create.tsKey.create.text,
+			newText: updateDescriptionText.upsert.create.tsKey.create.text,
+			previousText: existing?.description?.tsKey.text,
+			previousCrowdinId: existing?.description?.tsKey.crowdinId,
 			context: buildContextUrl(slug, linkLocationId ?? undefined),
 		})
-		if (crowdin.id) {
-			updateDescriptionText.upsert.create.tsKey.create.crowdinId = crowdin.id
+		if (crowdinId) {
+			updateDescriptionText.upsert.create.tsKey.create.crowdinId = crowdinId
 		}
 	}
 

--- a/packages/api/router/orgEmail/mutation.upsertMany.handler.ts
+++ b/packages/api/router/orgEmail/mutation.upsertMany.handler.ts
@@ -1,6 +1,6 @@
 import compact from 'just-compact'
 
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import { generateId, generateNestedFreeTextUpsert, getAuditedClient } from '@weareinreach/db'
 import {
 	connectOneId,
@@ -20,7 +20,11 @@ const upsertMany = async ({ ctx, input }: TRPCHandlerParams<TUpsertManySchema, '
 		where: {
 			id: { in: compact(data.map(({ id }) => id)) },
 		},
-		include: { services: true, locations: true },
+		include: {
+			services: true,
+			locations: true,
+			description: { select: { tsKey: { select: { text: true, crowdinId: true } } } },
+		},
 	})
 
 	// Crowdin sync (a network call to a third party) must not happen inside the DB transaction below -
@@ -61,14 +65,15 @@ const upsertMany = async ({ ctx, input }: TRPCHandlerParams<TUpsertManySchema, '
 					: undefined
 
 				if (descriptionText) {
-					const crowdin = await upsertSingleKey({
-						isDatabaseString: true,
+					const crowdinId = await syncDatabaseStringIfChanged({
 						key: descriptionText.upsert.create.tsKey.create.key,
-						text: descriptionText.upsert.create.tsKey.create.text,
+						newText: descriptionText.upsert.create.tsKey.create.text,
+						previousText: before?.description?.tsKey.text,
+						previousCrowdinId: before?.description?.tsKey.crowdinId,
 						context: buildContextUrl(slug),
 					})
-					if (crowdin.id) {
-						descriptionText.upsert.create.tsKey.create.crowdinId = crowdin.id
+					if (crowdinId) {
+						descriptionText.upsert.create.tsKey.create.crowdinId = crowdinId
 					}
 				}
 

--- a/packages/api/router/orgPhone/mutation.update.handler.ts
+++ b/packages/api/router/orgPhone/mutation.update.handler.ts
@@ -1,4 +1,4 @@
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import { generateNestedFreeTextUpsert, getAuditedClient } from '@weareinreach/db'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
@@ -20,13 +20,20 @@ const update = async ({ ctx, input }: TRPCHandlerParams<TUpdateSchema, 'protecte
 			where: { id: orgId },
 			select: { slug: true },
 		})
-		const crowdin = await upsertSingleKey({
-			isDatabaseString: true,
+		const existing = await prisma.orgPhone.findUnique({
+			where: { id },
+			select: { description: { select: { tsKey: { select: { text: true, crowdinId: true } } } } },
+		})
+		const crowdinId = await syncDatabaseStringIfChanged({
 			key: textData.upsert.create.tsKey.create.key,
-			text: textData.upsert.create.tsKey.create.text,
+			newText: textData.upsert.create.tsKey.create.text,
+			previousText: existing?.description?.tsKey.text,
+			previousCrowdinId: existing?.description?.tsKey.crowdinId,
 			context: buildContextUrl(slug),
 		})
-		textData.upsert.create.tsKey.create.crowdinId = crowdin.id
+		if (crowdinId) {
+			textData.upsert.create.tsKey.create.crowdinId = crowdinId
+		}
 	}
 
 	const result = await prisma.$transaction(async (tx) => {

--- a/packages/api/router/orgPhone/mutation.upsert.handler.ts
+++ b/packages/api/router/orgPhone/mutation.upsert.handler.ts
@@ -1,4 +1,4 @@
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import {
 	generateId,
 	generateNestedFreeText,
@@ -72,13 +72,21 @@ const upsert = async ({ ctx, input }: TRPCHandlerParams<TUpsertSchema, 'protecte
 				where: { id: orgId },
 				select: { slug: true },
 			})
-			const crowdin = await upsertSingleKey({
-				isDatabaseString: true,
-				...description.crowdinArgs,
+			const existing = isCreate
+				? null
+				: await prisma.orgPhone.findUnique({
+						where: { id },
+						select: { description: { select: { tsKey: { select: { text: true, crowdinId: true } } } } },
+					})
+			const crowdinId = await syncDatabaseStringIfChanged({
+				key: description.crowdinArgs.key,
+				newText: description.crowdinArgs.text,
+				previousText: existing?.description?.tsKey.text,
+				previousCrowdinId: existing?.description?.tsKey.crowdinId,
 				context: buildContextUrl(slug),
 			})
-			if (description.prisma.create?.tsKey?.create) {
-				description.prisma.create.tsKey.create.crowdinId = crowdin.id
+			if (description.prisma.create?.tsKey?.create && crowdinId) {
+				description.prisma.create.tsKey.create.crowdinId = crowdinId
 			}
 		}
 

--- a/packages/api/router/orgPhone/query.forEditDrawer.handler.ts
+++ b/packages/api/router/orgPhone/query.forEditDrawer.handler.ts
@@ -7,24 +7,12 @@ import { type TRPCHandlerParams } from '~api/types/handler'
 import { type TForEditDrawerSchema } from './query.forEditDrawer.schema'
 
 const isExtension = (ext: string | null): ext is Extension => typeof ext === 'string' && ext.length > 0
-const getOrgId = async (phoneId: string) => {
-	const org = await prisma.organization.findFirstOrThrow({
-		where: {
-			OR: [
-				{ phones: { some: { phoneId } } },
-				{ locations: { some: { phones: { some: { phoneId } } } } },
-				{ services: { some: { phones: { some: { orgPhoneId: phoneId } } } } },
-			],
-		},
-		select: { id: true },
-	})
-	return org.id
-}
 
 const forEditDrawer = async ({ input }: TRPCHandlerParams<TForEditDrawerSchema>) => {
 	try {
+		const { id, orgId } = input
 		const result = await prisma.orgPhone.findUnique({
-			where: input,
+			where: { id },
 			select: {
 				id: true,
 				number: true,
@@ -43,7 +31,6 @@ const forEditDrawer = async ({ input }: TRPCHandlerParams<TForEditDrawerSchema>)
 		if (!result) {
 			return null
 		}
-		const orgId = await getOrgId(input.id)
 		const { country, description, number, ext, ...rest } = result
 
 		const parsedPhone = parsePhoneNumber(number, isSupportedCountry(country.cca2) ? country.cca2 : undefined)

--- a/packages/api/router/orgPhone/query.forEditDrawer.schema.ts
+++ b/packages/api/router/orgPhone/query.forEditDrawer.schema.ts
@@ -2,5 +2,8 @@ import { z } from 'zod'
 
 import { prefixedId } from '~api/schemas/idPrefix'
 
-export const ZForEditDrawerSchema = z.object({ id: prefixedId('orgPhone') })
+export const ZForEditDrawerSchema = z.object({
+	id: prefixedId('orgPhone'),
+	orgId: prefixedId('organization'),
+})
 export type TForEditDrawerSchema = z.infer<typeof ZForEditDrawerSchema>

--- a/packages/api/router/orgWebsite/mutation.upsert.handler.ts
+++ b/packages/api/router/orgWebsite/mutation.upsert.handler.ts
@@ -1,4 +1,4 @@
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import {
 	generateId,
 	generateNestedFreeText,
@@ -70,13 +70,21 @@ const upsert = async ({ ctx, input }: TRPCHandlerParams<TUpsertSchema, 'protecte
 				where: { id: organizationId },
 				select: { slug: true },
 			})
-			const crowdin = await upsertSingleKey({
-				isDatabaseString: true,
-				...description.crowdinArgs,
+			const existing = isCreate
+				? null
+				: await prisma.orgWebsite.findUnique({
+						where: { id },
+						select: { description: { select: { tsKey: { select: { text: true, crowdinId: true } } } } },
+					})
+			const crowdinId = await syncDatabaseStringIfChanged({
+				key: description.crowdinArgs.key,
+				newText: description.crowdinArgs.text,
+				previousText: existing?.description?.tsKey.text,
+				previousCrowdinId: existing?.description?.tsKey.crowdinId,
 				context: buildContextUrl(slug, orgLocationId ?? undefined),
 			})
-			if (description.prisma.create?.tsKey?.create) {
-				description.prisma.create.tsKey.create.crowdinId = crowdin.id
+			if (description.prisma.create?.tsKey?.create && crowdinId) {
+				description.prisma.create.tsKey.create.crowdinId = crowdinId
 			}
 		}
 

--- a/packages/api/router/organization/mutation.updateBasic.handler.ts
+++ b/packages/api/router/organization/mutation.updateBasic.handler.ts
@@ -1,4 +1,4 @@
-import { addSingleKey, buildContextUrl, updateSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import {
 	generateId,
 	generateNestedFreeTextUpsert,
@@ -31,7 +31,7 @@ const updateBasic = async ({ ctx, input }: TRPCHandlerParams<TUpdateBasicSchema,
 				oldSlugs: {
 					select: { from: true },
 				},
-				description: { select: { tsKey: { select: { crowdinId: true, key: true } } } },
+				description: { select: { tsKey: { select: { crowdinId: true, key: true, text: true } } } },
 			},
 		})
 
@@ -71,30 +71,14 @@ const updateBasic = async ({ ctx, input }: TRPCHandlerParams<TUpdateBasicSchema,
 				type: 'orgDesc',
 				text: input.description,
 			})
-			if (existing.description?.tsKey.crowdinId) {
-				console.log('update crowdin', {
-					key: existing.description.tsKey.key,
-					isDatabaseString: true,
-					updatedString: upsertDescription.upsert.update.tsKey.update.text,
-				})
-				await updateSingleKey({
-					key: existing.description.tsKey.key,
-					isDatabaseString: true,
-					updatedString: upsertDescription.upsert.update.tsKey.update.text,
-					context: buildContextUrl(orgSlug),
-				})
-			} else {
-				console.log('add crowdin', {
-					isDatabaseString: true,
-					key: upsertDescription.upsert.create.tsKey.create.key,
-					text: upsertDescription.upsert.create.tsKey.create.text,
-				})
-				const { id: crowdinId } = await addSingleKey({
-					isDatabaseString: true,
-					key: upsertDescription.upsert.create.tsKey.create.key,
-					text: upsertDescription.upsert.create.tsKey.create.text,
-					context: buildContextUrl(orgSlug),
-				})
+			const crowdinId = await syncDatabaseStringIfChanged({
+				key: existing.description?.tsKey.key ?? upsertDescription.upsert.create.tsKey.create.key,
+				newText: upsertDescription.upsert.create.tsKey.create.text,
+				previousText: existing.description?.tsKey.text,
+				previousCrowdinId: existing.description?.tsKey.crowdinId,
+				context: buildContextUrl(orgSlug),
+			})
+			if (crowdinId) {
 				upsertDescription.upsert.create.tsKey.create.crowdinId = crowdinId
 			}
 			data.description = upsertDescription

--- a/packages/api/router/organization/query.forOrgPageEdits.handler.ts
+++ b/packages/api/router/organization/query.forOrgPageEdits.handler.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@weareinreach/db'
-import { attributes, freeText } from '~api/schemas/selects/common'
+import { freeText } from '~api/schemas/selects/common'
+import { attributesForOrgEdit } from '~api/schemas/selects/org'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
 import { type TForOrgPageEditsSchema } from './query.forOrgPageEdits.schema'
@@ -8,85 +9,73 @@ import { formatAddressVisiblity } from '../location/lib.formatAddressVisibility'
 const forOrgPageEdits = async ({ input }: TRPCHandlerParams<TForOrgPageEditsSchema>) => {
 	const { slug } = input
 
-	// We'll use Promise.all to run all database queries concurrently for better performance.
-	const [org, lastUpdatedAuditResult, firstPublishedUpdateResult] = await Promise.all([
-		// 1. The existing query to fetch all organization data.
-		// We've added `createdAt` and `updatedAt` to the select statement.
-		prisma.organization.findUniqueOrThrow({
-			where: {
-				slug,
+	const org = await prisma.organization.findUniqueOrThrow({
+		where: {
+			slug,
+		},
+		select: {
+			id: true,
+			name: true,
+			slug: true,
+			published: true,
+			deleted: true,
+			lastVerified: true,
+			createdAt: true, // We need this for the fallback logic
+			updatedAt: true, // Now also fetching the organization's own updatedAt field
+			allowedEditors: { where: { authorized: true }, select: { userId: true } },
+			description: freeText,
+			reviews: {
+				select: { id: true },
 			},
-			select: {
-				id: true,
-				name: true,
-				slug: true,
-				published: true,
-				deleted: true,
-				lastVerified: true,
-				createdAt: true, // We need this for the fallback logic
-				updatedAt: true, // Now also fetching the organization's own updatedAt field
-				allowedEditors: { where: { authorized: true }, select: { userId: true } },
-				description: freeText,
-				reviews: {
-					select: { id: true },
+			locations: {
+				select: {
+					id: true,
+					street1: true,
+					street2: true,
+					city: true,
+					postCode: true,
+					country: { select: { cca2: true } },
+					govDist: { select: { abbrev: true, tsKey: true, tsNs: true } },
+					addressVisibility: true,
+					latitude: true,
+					longitude: true,
 				},
-				locations: {
-					select: {
-						id: true,
-						street1: true,
-						street2: true,
-						city: true,
-						postCode: true,
-						country: { select: { cca2: true } },
-						govDist: { select: { abbrev: true, tsKey: true, tsNs: true } },
-						addressVisibility: true,
-						latitude: true,
-						longitude: true,
-					},
-					orderBy: [{ deleted: 'asc' }, { published: 'desc' }, { createdAt: 'desc' }],
-				},
-				attributes,
+				orderBy: [{ deleted: 'asc' }, { published: 'desc' }, { createdAt: 'desc' }],
 			},
-		}),
+			attributes: attributesForOrgEdit,
+		},
+	})
 
-		// 2. A raw SQL query to get the most recent audit trail timestamp for this organization.
-		// This will be used for the 'last updated' date.
+	// Both queries key off the org's real id against the already-indexed `recordId`
+	// column (GIN index) instead of parsing every row's JSON payload, so this stays a
+	// fast, scoped lookup no matter how large the shared AuditTrail table grows.
+	const [lastUpdatedAuditResult, firstPublishedUpdateResult] = await Promise.all([
+		// The most recent change to this Organization's own row -- used for 'last updated'.
 		prisma.$queryRaw<{ timestamp: Date }[]>`
       SELECT
         "timestamp"
       FROM
         "AuditTrail"
       WHERE
-        COALESCE(
-          JSONB_EXTRACT_PATH_TEXT("new", 'organizationId'),
-          JSONB_EXTRACT_PATH_TEXT("new", 'orgId'),
-          JSONB_EXTRACT_PATH_TEXT("new", 'organization_id')
-        ) = ${slug}
+        "table" = 'Organization'
+        AND "recordId" @> ARRAY[${org.id}]::text[]
       ORDER BY
         "timestamp" DESC
       LIMIT 1;
     `,
 
-		// 3. A raw SQL query to find the first time the `published` flag was changed from false to true.
-		// This will be used for the 'first published' date.
+		// The first time `published` flipped from false to true -- used for 'first published'.
 		prisma.$queryRaw<{ timestamp: Date }[]>`
       SELECT
         "timestamp"
       FROM
         "AuditTrail"
       WHERE
-        "operation" = 'UPDATE'
-        AND COALESCE(
-          JSONB_EXTRACT_PATH_TEXT("old", 'published')
-        ) = 'false'
-        AND COALESCE(
-          JSONB_EXTRACT_PATH_TEXT("new", 'published')
-        ) = 'true'
-        AND COALESCE(
-          JSONB_EXTRACT_PATH_TEXT("new", 'organizationId'),
-          JSONB_EXTRACT_PATH_TEXT("new", 'orgId'),
-          JSONB_EXTRACT_PATH_TEXT("new", 'organization_id')
-        ) = ${slug}
+        "table" = 'Organization'
+        AND "recordId" @> ARRAY[${org.id}]::text[]
+        AND "operation" = 'UPDATE'
+        AND ("old"->>'published') = 'false'
+        AND ("new"->>'published') = 'true'
       ORDER BY
         "timestamp" ASC
       LIMIT 1;

--- a/packages/api/router/service/mutation.upsert.handler.ts
+++ b/packages/api/router/service/mutation.upsert.handler.ts
@@ -1,4 +1,4 @@
-import { buildContextUrl, upsertSingleKey } from '@weareinreach/crowdin/api'
+import { buildContextUrl, syncDatabaseStringIfChanged } from '@weareinreach/crowdin/api'
 import { generateNestedFreeTextUpsert, getAuditedClient } from '@weareinreach/db'
 import { type TRPCHandlerParams } from '~api/types/handler'
 
@@ -37,23 +37,38 @@ const upsert = async ({ ctx, input }: TRPCHandlerParams<TUpsertSchema, 'protecte
 		where: { id: orgId },
 		select: { slug: true },
 	})
+	const existing = input.id
+		? await prisma.orgService.findUnique({
+				where: { id: input.id },
+				select: {
+					serviceName: { select: { tsKey: { select: { text: true, crowdinId: true } } } },
+					description: { select: { tsKey: { select: { text: true, crowdinId: true } } } },
+				},
+			})
+		: null
 	if (serviceName) {
-		const crowdin = await upsertSingleKey({
-			isDatabaseString: true,
+		const crowdinId = await syncDatabaseStringIfChanged({
 			key: serviceName.upsert.create.tsKey.create.key,
-			text: serviceName.upsert.create.tsKey.create.text,
+			newText: serviceName.upsert.create.tsKey.create.text,
+			previousText: existing?.serviceName?.tsKey.text,
+			previousCrowdinId: existing?.serviceName?.tsKey.crowdinId,
 			context: buildContextUrl(slug, attachToLocation),
 		})
-		serviceName.upsert.create.tsKey.create.crowdinId = crowdin.id
+		if (crowdinId) {
+			serviceName.upsert.create.tsKey.create.crowdinId = crowdinId
+		}
 	}
 	if (description) {
-		const crowdin = await upsertSingleKey({
-			isDatabaseString: true,
+		const crowdinId = await syncDatabaseStringIfChanged({
 			key: description.upsert.create.tsKey.create.key,
-			text: description.upsert.create.tsKey.create.text,
+			newText: description.upsert.create.tsKey.create.text,
+			previousText: existing?.description?.tsKey.text,
+			previousCrowdinId: existing?.description?.tsKey.crowdinId,
 			context: buildContextUrl(slug, attachToLocation),
 		})
-		description.upsert.create.tsKey.create.crowdinId = crowdin.id
+		if (crowdinId) {
+			description.upsert.create.tsKey.create.crowdinId = crowdinId
+		}
 	}
 
 	const result = await prisma.$transaction(async (tx) => {

--- a/packages/api/schemas/selects/org.ts
+++ b/packages/api/schemas/selects/org.ts
@@ -5,6 +5,52 @@ import { type Context } from '~api/lib'
 
 import { attributes, countryWithoutGeo, freeText, isPublic, phoneSelectPublic } from './common'
 
+/**
+ * Trimmed version of `attributes` (./common) for the org edit page, which only ever renders
+ * leadership/service-focus badges -- not the full public-page detail (country, language, translation text,
+ * govDist chains) that the shared select also pulls in.
+ */
+export const attributesForOrgEdit = {
+	where: {
+		attribute: {
+			active: true,
+			categories: {
+				some: {
+					category: {
+						active: true,
+					},
+				},
+			},
+		},
+	},
+	select: {
+		id: true,
+		attribute: {
+			select: {
+				id: true,
+				tsKey: true,
+				tsNs: true,
+				icon: true,
+				iconBg: true,
+				categories: {
+					select: {
+						category: {
+							select: {
+								tag: true,
+							},
+						},
+					},
+				},
+				_count: {
+					select: {
+						parents: true,
+					},
+				},
+			},
+		},
+	},
+} satisfies Prisma.OrgService$attributesArgs
+
 type OrgIncludeKeys = z.ZodObject<
 	{
 		[k in keyof Omit<Prisma.OrganizationInclude, '_count'>]-?: z.ZodDefault<z.ZodBoolean>

--- a/packages/crowdin/api/index.ts
+++ b/packages/crowdin/api/index.ts
@@ -43,6 +43,37 @@ export const addSingleKeyFromNestedFreetextCreate = async (
 	throw new Error('Unable to add string to Crowdin, check args.')
 }
 
+/**
+ * Syncs a database-backed translation string to Crowdin, but only when there's actually something to send: if
+ * the previously-saved text matches what's being saved now, this skips the network round trip entirely. When
+ * a crowdinId is already known, this also skips the lookup-by-key call that `upsertSingleKey` would otherwise
+ * make, going straight to the patch. Returns the crowdinId to persist on the record (unchanged, patched, or
+ * newly-added).
+ */
+export const syncDatabaseStringIfChanged = async (params: {
+	key: string
+	newText: string
+	previousText?: string | null
+	previousCrowdinId?: number | null
+	context?: string
+}): Promise<number | undefined> => {
+	const { key, newText, previousText, previousCrowdinId, context } = params
+	if (previousCrowdinId && previousText === newText) {
+		return previousCrowdinId
+	}
+	if (previousCrowdinId) {
+		await updateSingleKey({
+			crowdinId: previousCrowdinId,
+			updatedString: newText,
+			isDatabaseString: true,
+			context,
+		})
+		return previousCrowdinId
+	}
+	const { id } = await upsertSingleKey({ isDatabaseString: true, key, text: newText, context })
+	return id
+}
+
 export { branches, sourceFiles, projectId } from '../constants'
 export { buildContextUrl } from '../common/buildContextUrl'
 

--- a/packages/ui/components/data-display/ContactInfo/Emails.tsx
+++ b/packages/ui/components/data-display/ContactInfo/Emails.tsx
@@ -153,7 +153,7 @@ const EmailsEdit = ({ parentId = '' }: EmailsProps) => {
 		}
 	)
 	const linkToLocation = api.orgEmail.locationLink.useMutation({
-		onSuccess: () => apiUtils.orgEmail.invalidate(),
+		onSuccess: () => apiUtils.orgEmail.forContactInfoEdit.invalidate({ parentId }),
 	})
 	const getTextVariant = useCallback(
 		(kind: 'email' | 'desc', published: boolean, deleted: boolean) => {

--- a/packages/ui/components/data-display/ContactInfo/PhoneNumbers.tsx
+++ b/packages/ui/components/data-display/ContactInfo/PhoneNumbers.tsx
@@ -135,7 +135,7 @@ const PhoneNumbersEdit = ({ parentId = '' }: PhoneNumbersProps) => {
 		}
 	)
 	const linkToLocation = api.orgPhone.locationLink.useMutation({
-		onSuccess: () => apiUtils.orgPhone.invalidate(),
+		onSuccess: () => apiUtils.orgPhone.forContactInfoEdit.invalidate({ parentId }),
 	})
 	const getTextVariant = useCallback(
 		(kind: 'value' | 'desc', published: boolean, deleted: boolean) => {

--- a/packages/ui/components/data-display/ContactInfo/SocialMedia.tsx
+++ b/packages/ui/components/data-display/ContactInfo/SocialMedia.tsx
@@ -66,7 +66,7 @@ const SocialMediaEdit = ({ parentId = '' }: SocialMediaProps) => {
 		}
 	)
 	const linkToLocation = api.orgSocialMedia.locationLink.useMutation({
-		onSuccess: () => apiUtils.orgSocialMedia.invalidate(),
+		onSuccess: () => apiUtils.orgSocialMedia.forContactInfoEdits.invalidate({ parentId }),
 	})
 	const getTextVariants = useCallback(
 		({ published, deleted }: { published: boolean; deleted: boolean }) => {

--- a/packages/ui/components/data-display/ContactInfo/Websites.tsx
+++ b/packages/ui/components/data-display/ContactInfo/Websites.tsx
@@ -139,7 +139,7 @@ const WebsitesEdit = ({ parentId = '' }: WebsitesProps) => {
 		{ enabled: isLocation }
 	)
 	const linkToLocation = api.orgWebsite.locationLink.useMutation({
-		onSuccess: () => apiUtils.orgWebsite.invalidate(),
+		onSuccess: () => apiUtils.orgWebsite.forContactInfoEdit.invalidate({ parentId }),
 	})
 	const getTextVariant = useCallback(
 		(kind: 'value' | 'desc', published: boolean, deleted: boolean) => {

--- a/packages/ui/components/data-portal/AddressAutocomplete/index.tsx
+++ b/packages/ui/components/data-portal/AddressAutocomplete/index.tsx
@@ -50,7 +50,7 @@ const matchText = (
 }
 
 const AutoCompleteItem = forwardRef<HTMLDivElement, AutocompleteItem>(
-	({ value, subheading, placeId: _placeId, ...others }: AutocompleteItem, ref) => {
+	({ value, subheading, placeId: _placeId, label: _label, ...others }: AutocompleteItem, ref) => {
 		const { classes, cx } = useStyles()
 		const form = useFormContext()
 		if (!form) {
@@ -97,6 +97,15 @@ export const AddressAutocomplete = <T extends AddressSchema>({
 	const [searchTerm, setSearchTerm] = useState<string>('')
 	const [search] = useDebouncedValue(searchTerm, 200)
 	const [googlePlaceId, setGooglePlaceId] = useState<string>('')
+	// The street text of whatever suggestion the user actually picked, kept alongside the placeId
+	// it came from. Google's geocode lookup for a placeId sometimes has no confirmed street number
+	// (common for routes/interpolated ranges) even though the suggestion the user selected showed
+	// one - in that case we fall back to what they selected rather than silently dropping it.
+	// Tying it to the placeId (not just setting/clearing it) means a later, unrelated geocode
+	// lookup (e.g. from `getAndSetCoords` below) can never accidentally reuse a stale value.
+	const [selectedPrediction, setSelectedPrediction] = useState<{ placeId: string; label: string } | null>(
+		null
+	)
 	const { t, i18n } = useTranslation(['gov-dist'])
 
 	const disableFieldUntilCountry = !selectedCountryId
@@ -163,10 +172,13 @@ export const AddressAutocomplete = <T extends AddressSchema>({
 			const country = countryOptions?.find(({ cca2 }) => cca2 === result.country)
 			invariant(country)
 			const govDist = country?.govDist.find(({ abbrev }) => abbrev === result.govDist)
-			const formattedStreet1 =
-				compact([result.streetNumber, result.streetName]).length === 2
-					? compact([result.streetNumber, result.streetName]).join(' ')
+			const streetParts = compact([result.streetNumber, result.streetName])
+			const geocodedStreet1 = streetParts.length ? streetParts.join(' ') : undefined
+			const predictedFallback =
+				!result.streetNumber && selectedPrediction?.placeId === googlePlaceId
+					? selectedPrediction.label
 					: undefined
+			const formattedStreet1 = predictedFallback ?? geocodedStreet1
 
 			if (isFullAddress) {
 				setFormValue(getFieldName('street1'), formattedStreet1 as FieldPathValue<T, Path<T>>)
@@ -191,6 +203,8 @@ export const AddressAutocomplete = <T extends AddressSchema>({
 		}
 	}, [
 		geoCodedAddress,
+		googlePlaceId,
+		selectedPrediction,
 		addressVisibility,
 		countryOptions,
 		setFormValue,
@@ -205,9 +219,26 @@ export const AddressAutocomplete = <T extends AddressSchema>({
 			if (!item.placeId) {
 				return
 			}
+			setSelectedPrediction({ placeId: item.placeId, label: item.label ?? item.value })
 			setGooglePlaceId(item.placeId)
 		},
 		[setGooglePlaceId]
+	)
+
+	// Mantine's Autocomplete fires `onChange` both when the user types AND when they commit a
+	// suggestion (the commit writes the suggestion's full display text into the field, which
+	// bubbles through this same onChange). Without this guard, committing a suggestion re-feeds
+	// that full text back in as a brand-new search term, kicking off a second, unwanted lookup
+	// that races the geocode-by-place-id call and can clobber street1 with a different match.
+	const handleSearchChange = useCallback(
+		(value: string) => {
+			const isSelectionEcho = autoCompleteSearch?.results.some((item) => item.value === value)
+			if (isSelectionEcho) {
+				return
+			}
+			setSearchTerm(value)
+		},
+		[autoCompleteSearch]
 	)
 
 	const getAndSetCoords = useCallback(
@@ -277,7 +308,7 @@ export const AddressAutocomplete = <T extends AddressSchema>({
 			onItemSubmit={handleAutocompleteSelection}
 			control={control}
 			name={getFieldName('street1')}
-			onChange={setSearchTerm}
+			onChange={handleSearchChange}
 			disabled={disableFieldUntilCountry}
 			required
 		/>
@@ -375,6 +406,8 @@ export interface AddressAutocompleteProps<T extends FieldValues> extends UseCont
 interface AutocompleteItem {
 	value: string
 	name?: string
+	/** The street-only portion of the suggestion (Google's `structured_formatting.main_text`). */
+	label?: string
 	subheading?: string
 	placeId?: string
 }

--- a/packages/ui/components/data-portal/EmailDrawer/index.tsx
+++ b/packages/ui/components/data-portal/EmailDrawer/index.tsx
@@ -63,15 +63,15 @@ export const _EmailDrawer = forwardRef<HTMLButtonElement, EmailDrawerProps>(
 
 		const hasLocationId = typeof router.query.orgLocationId === 'string' ? router.query.orgLocationId : null
 
+		const [drawerOpened, drawerHandler] = useDisclosure(false)
+		const [modalOpened, modalHandler] = useDisclosure(false)
 		const { data: initialData, isFetching } = api.orgEmail.forEditDrawer.useQuery(
 			{ id: emailId },
 			{
-				enabled: !!orgId && (!!id || !createNew),
+				enabled: drawerOpened && !!orgId && (!!id || !createNew),
 				select: (data) => (data ? { ...data, orgId: orgId ?? '' } : data),
 			}
 		)
-		const [drawerOpened, drawerHandler] = useDisclosure(false)
-		const [modalOpened, modalHandler] = useDisclosure(false)
 		const { classes } = useStyles()
 		const apiUtils = api.useUtils()
 		const notifySave = useNewNotification({ displayText: 'Saved', icon: 'success' })
@@ -104,9 +104,20 @@ export const _EmailDrawer = forwardRef<HTMLButtonElement, EmailDrawerProps>(
 		const [isSaved, setIsSaved] = useState(formIsDirty)
 
 		const emailUpdate = api.orgEmail.update.useMutation({
+			onSettled: () => {
+				apiUtils.orgEmail.forContactInfoEdit.invalidate()
+				apiUtils.orgEmail.forContactInfo.invalidate()
+				// This drawer's own detail query is keyed by this specific email id - without
+				// marking it stale too, reopening this same email later would show the pre-save
+				// data, making a second edit silently start from a stale field state instead of
+				// what was just saved. `refetchType: 'none'` marks it stale for next time without
+				// forcing an immediate refetch here - nothing is displaying this query while the
+				// drawer is closed, and forcing one batches it alongside the forContactInfoEdit
+				// refetch above in a way that ends up blocking that one from reaching the list.
+				apiUtils.orgEmail.forEditDrawer.invalidate({ id: emailId }, { refetchType: 'none' })
+			},
 			onSuccess: (data) => {
 				setIsSaved(true)
-				apiUtils.orgEmail.invalidate()
 				reset(data)
 				notifySave()
 				modalHandler.close()
@@ -114,7 +125,9 @@ export const _EmailDrawer = forwardRef<HTMLButtonElement, EmailDrawerProps>(
 			},
 		})
 		const unlinkFromLocation = api.orgEmail.locationLink.useMutation({
-			onSuccess: () => apiUtils.orgEmail.invalidate(),
+			onSuccess: () => {
+				apiUtils.orgEmail.forContactInfoEdit.invalidate()
+			},
 		})
 		// useEffect(() => {
 		// 	if (createNew && orgId) {

--- a/packages/ui/components/data-portal/LocationDrawer/index.tsx
+++ b/packages/ui/components/data-portal/LocationDrawer/index.tsx
@@ -60,8 +60,7 @@ export const LocationDrawer = forwardRef<HTMLButtonElement, ButtonProps>((props,
 	const createLocation = api.location.create.useMutation({
 		onSuccess: () => {
 			modalHandler.close()
-			apiUtils.location.invalidate()
-			apiUtils.organization.invalidate()
+			apiUtils.organization.forOrgPageEdits.invalidate()
 			setIsSaved(true)
 			notifySave()
 			setTimeout(() => drawerHandler.close(), 500)

--- a/packages/ui/components/data-portal/PhoneDrawer/index.tsx
+++ b/packages/ui/components/data-portal/PhoneDrawer/index.tsx
@@ -18,13 +18,16 @@ import { useTranslation } from 'next-i18next'
 import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Checkbox, Select, TextInput } from 'react-hook-form-mantine'
+import { isValidPhoneNumber } from 'react-phone-number-input'
 import { z } from 'zod'
 
+import { type TUpsertSchema } from '@weareinreach/api/router/orgPhone/mutation.upsert.schema'
 import { generateId } from '@weareinreach/db/lib/idGen'
 import { Breadcrumb } from '~ui/components/core/Breadcrumb'
 import { Button } from '~ui/components/core/Button'
 import { PhoneNumberEntry } from '~ui/components/data-portal/PhoneNumberEntry/withHookForm'
 import { useOrgInfo } from '~ui/hooks/useOrgInfo'
+import { isCountryCode } from '~ui/hooks/usePhoneNumber'
 import { Icon } from '~ui/icon'
 import { trpc as api } from '~ui/lib/trpcClient'
 
@@ -62,20 +65,53 @@ const _PhoneDrawer = forwardRef<HTMLButtonElement, PhoneDrawerProps>(
 		}, [createNew, id])
 		const { id: orgId } = useOrgInfo()
 		const apiUtils = api.useUtils()
+		const [drawerOpened, drawerHandler] = useDisclosure(false)
+		const [modalOpened, modalHandler] = useDisclosure(false)
 		const { data: initialData, isFetching } = api.orgPhone.forEditDrawer.useQuery(
-			{ id: phoneId },
+			{ id: phoneId, orgId: orgId ?? '' },
 			{
-				enabled: !!orgId || !createNew,
+				enabled: drawerOpened && !!orgId,
 			}
 		)
 		const { data: phoneTypes } = api.fieldOpt.phoneTypes.useQuery(undefined, {
 			initialData: [],
 			select: (data) => data.map(({ id: value, tsKey, tsNs }) => ({ value, label: t(tsKey, { ns: tsNs }) })),
 		})
-		const [drawerOpened, drawerHandler] = useDisclosure(false)
-		const [modalOpened, modalHandler] = useDisclosure(false)
+		// Same query PhoneNumberEntry already makes internally - React Query dedupes this against
+		// that one rather than firing a second request, so this is free.
+		const { data: countryList } = api.fieldOpt.countries.useQuery({ activeForOrgs: true })
+		const countryCca2ById = useMemo(() => {
+			const lookup = new Map<string, string>()
+			countryList?.forEach(({ id, cca2 }) => lookup.set(id, cca2))
+			return lookup
+		}, [countryList])
 
 		const { classes } = useStyles()
+		// Built dynamically (rather than a module-level constant) because validating the phone
+		// number requires resolving the selected countryId to an ISO country code first, and that
+		// lookup table only exists once the countries query above has loaded. react-hook-form's
+		// per-field `rules` are silently ignored whenever a resolver is set (this form uses one),
+		// so the phone-format check has to live in the schema itself to actually run.
+		const formResolver = useMemo(
+			() =>
+				zodResolver(
+					FormSchema.superRefine((data, ctx) => {
+						if (!data.number) {
+							return
+						}
+						const rawCca2 = countryCca2ById.get(data.countryId)
+						const cca2 = rawCca2 && isCountryCode(rawCca2) ? rawCca2 : undefined
+						if (!isValidPhoneNumber(data.number, cca2)) {
+							ctx.addIssue({
+								code: z.ZodIssueCode.custom,
+								path: ['number'],
+								message: cca2 ? `Not a valid phone number for ${cca2}` : 'Not a valid phone number',
+							})
+						}
+					})
+				),
+			[countryCca2ById]
+		)
 		const {
 			control,
 			handleSubmit,
@@ -85,7 +121,7 @@ const _PhoneDrawer = forwardRef<HTMLButtonElement, PhoneDrawerProps>(
 			watch,
 			setValue: setFormValue,
 		} = useForm<FormSchema>({
-			resolver: zodResolver(FormSchema),
+			resolver: formResolver,
 			values: initialData ?? undefined,
 			defaultValues: {
 				id: phoneId,
@@ -99,24 +135,89 @@ const _PhoneDrawer = forwardRef<HTMLButtonElement, PhoneDrawerProps>(
 		const { isDirty: formIsDirty } = formState
 		const [isSaved, setIsSaved] = useState(formIsDirty)
 		const hasLocationId = typeof router.query.orgLocationId === 'string' ? router.query.orgLocationId : null
+
+		// Invalidating forContactInfoEdit and letting it refetch has turned out to be racy in
+		// practice: two GET requests for the same query can land out of order, and if the stale
+		// one (fetched before this save committed) resolves after the fresh one, it silently wins
+		// and the list shows old data even though the save succeeded. Patching the cache directly
+		// with what we just saved sidesteps that race entirely instead of depending on which
+		// response happens to arrive last. This only patches the org-level list plus the
+		// location-level list if this phone belongs to one - phoneType and the description's
+		// translation key are left as whatever's already cached (only the description text is
+		// updated) since those aren't available in the form's submitted values; a real refetch
+		// (still triggered, just without forcing this immediate race-prone one) corrects that on
+		// next natural load if either was actually changed.
+		const patchContactListCaches = useCallback(
+			(submitted: TUpsertSchema) => {
+				// `update`'s zod branch technically allows every field but `id` to be omitted (only
+				// `create` requires `number`/`countryId`), even though this drawer's form always
+				// submits all of them - falling back to the existing cached value covers that gap
+				// defensively rather than assuming the type's full possibility space away.
+				const cca2 = submitted.countryId ? countryCca2ById.get(submitted.countryId) : undefined
+				const parentIds = [orgId, hasLocationId].filter((value): value is string => Boolean(value))
+				for (const parentId of parentIds) {
+					apiUtils.orgPhone.forContactInfoEdit.setData({ parentId }, (old) => {
+						if (!old) {
+							return old
+						}
+						const next = old.map((item) =>
+							item.id === submitted.id
+								? {
+										...item,
+										number: submitted.number ?? item.number,
+										ext: submitted.ext ?? item.ext,
+										primary: submitted.primary ?? item.primary,
+										locationOnly: submitted.locationOnly ?? item.locationOnly,
+										published: submitted.published ?? item.published,
+										deleted: submitted.deleted ?? item.deleted,
+										country: cca2 ?? item.country,
+										description:
+											submitted.description === undefined
+												? item.description
+												: submitted.description === null
+													? null
+													: { key: item.description?.key ?? '', defaultText: submitted.description },
+									}
+								: item
+						)
+						return next.toSorted(
+							(a, b) => Number(b.published) - Number(a.published) || Number(a.deleted) - Number(b.deleted)
+						)
+					})
+				}
+			},
+			[apiUtils, orgId, hasLocationId, countryCca2ById]
+		)
+
 		const siteUpdate = api.orgPhone.upsert.useMutation({
-			onSettled: (data) => {
-				apiUtils.orgPhone.invalidate()
+			onSettled: (data, _error, variables) => {
+				patchContactListCaches(variables)
+				apiUtils.orgPhone.forContactInfoEdit.invalidate(undefined, { refetchType: 'none' })
+				apiUtils.orgPhone.forContactInfo.invalidate()
+				// This drawer's own detail query is keyed by this specific phone id - without
+				// marking it stale too, reopening this same phone later would show the pre-save
+				// data, making a second edit silently start from a stale checkbox state instead
+				// of what was just saved. `refetchType: 'none'` marks it stale for next time
+				// without forcing an immediate refetch here - nothing is displaying this query
+				// while the drawer is closed, and forcing one batches it alongside the
+				// forContactInfoEdit refetch above in a way that ends up blocking that one from
+				// reaching the list.
+				apiUtils.orgPhone.forEditDrawer.invalidate(
+					{ id: phoneId, orgId: orgId ?? '' },
+					{ refetchType: 'none' }
+				)
 				reset(data)
 			},
 			onSuccess: () => {
 				setIsSaved(true)
-				apiUtils.orgPhone.invalidate()
 				modalHandler.close()
 				drawerHandler.close()
 			},
 		})
-		// const isSaved = /*siteUpdate.isSuccess &&*/ !formState.isDirty
 		const unlinkFromLocation = api.orgPhone.locationLink.useMutation({
 			onSuccess: () => {
 				drawerHandler.close()
-
-				apiUtils.orgPhone.invalidate()
+				apiUtils.orgPhone.forContactInfoEdit.invalidate()
 			},
 		})
 		useEffect(() => {

--- a/packages/ui/components/data-portal/PhoneNumberEntry/withHookForm.tsx
+++ b/packages/ui/components/data-portal/PhoneNumberEntry/withHookForm.tsx
@@ -1,7 +1,7 @@
 import { ErrorMessage } from '@hookform/error-message'
-import { TextInput, type TextInputProps } from '@mantine/core'
+import { Text, TextInput, type TextInputProps } from '@mantine/core'
 import { AsYouType } from 'libphonenumber-js'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
 	type Control,
 	type FieldValues,
@@ -9,8 +9,8 @@ import {
 	type UseControllerProps,
 	useWatch,
 } from 'react-hook-form'
-import { Select, type SelectProps } from 'react-hook-form-mantine'
-import { parsePhoneNumber } from 'react-phone-number-input'
+import { TextInput as FormTextInput, Select, type SelectProps } from 'react-hook-form-mantine'
+import { isValidPhoneNumber, parsePhoneNumber } from 'react-phone-number-input'
 import PhoneInput, { type Props as PhoneInputProps } from 'react-phone-number-input/react-hook-form-input'
 
 import { isCountryCode } from '~ui/hooks/usePhoneNumber'
@@ -88,6 +88,24 @@ export const PhoneNumberEntry = <T extends FieldValues>({
 
 	const phoneFormatter = new AsYouType(activeCountry)
 
+	// The masked phone input below can only display values it can actually parse. Some existing
+	// records (bad legacy data, or a malformed number that was saved before validation caught it)
+	// don't parse at all, which made the field render blank with no indication anything was even
+	// saved. This checks the value once, the first time it loads in (not on every keystroke, so
+	// correcting it doesn't cause the input to flicker/swap mid-edit), and falls back to a plain
+	// text field showing the raw value if the masked input can't represent it.
+	const [showRawFallback, setShowRawFallback] = useState(false)
+	const hasCheckedInitialValue = useRef(false)
+	useEffect(() => {
+		if (hasCheckedInitialValue.current || !phoneNumber) {
+			return
+		}
+		hasCheckedInitialValue.current = true
+		if (!parsePhoneNumber(phoneNumber, activeCountry)) {
+			setShowRawFallback(true)
+		}
+	}, [phoneNumber, activeCountry])
+
 	useEffect(() => {
 		if (phoneNumber) {
 			phoneFormatter.input(phoneNumber)
@@ -136,11 +154,20 @@ export const PhoneNumberEntry = <T extends FieldValues>({
 	) : undefined
 	const phoneValidationRules = {
 		validate: {
+			// Catches anything that isn't a real, deliverable number for the selected country
+			// (wrong length, bad area code, etc.) - without this, a malformed number silently
+			// saved as-is, since neither this form nor the API rejected it.
+			validPhoneNumber: (number?: string) => {
+				if (!number || !activeCountry) {
+					return true
+				}
+				return isValidPhoneNumber(number, activeCountry) || `Not a valid phone number for ${activeCountry}`
+			},
 			invalidCountry: (number?: string) => {
 				if (number) {
 					const parsed = parsePhoneNumber(number)
 					if (parsed?.country) {
-						return validCountries.includes(parsed.country) ?? `Country not enabled: ${parsed.country}`
+						return validCountries.includes(parsed.country) || `Country not enabled: ${parsed.country}`
 					}
 				}
 				return true
@@ -148,8 +175,29 @@ export const PhoneNumberEntry = <T extends FieldValues>({
 		},
 	}
 
+	if (showRawFallback) {
+		return (
+			<>
+				<FormTextInput
+					name={peName}
+					control={control}
+					label={label}
+					required={required}
+					rules={phoneValidationRules}
+					rightSection={countrySelection}
+					rightSectionWidth={56}
+				/>
+				<Text size='xs' color='dimmed'>
+					This number couldn&apos;t be displayed in the normal format - showing the raw saved value. Re-enter
+					it to fix.
+				</Text>
+			</>
+		)
+	}
+
 	return (
 		<PhoneInput<TextInputProps, T>
+			country={activeCountry}
 			defaultCountry={DEFAULT_COUNTRY}
 			inputComponent={TextInput}
 			rightSection={countrySelection}

--- a/packages/ui/components/data-portal/ServiceEditDrawer/AttributeEditWrapper.tsx
+++ b/packages/ui/components/data-portal/ServiceEditDrawer/AttributeEditWrapper.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Button, Group, Modal, Text, Tooltip, useMantineTheme } from
 import { useDisclosure } from '@mantine/hooks'
 import { type ReactNode, useCallback, useMemo } from 'react'
 
+import { isIdFor } from '@weareinreach/db/lib/idGen'
 import { Icon } from '~ui/icon'
 import { trpc as api } from '~ui/lib/trpcClient'
 import { ModalText } from '~ui/modals/Service/ModalText'
@@ -11,7 +12,21 @@ export const AttributeEditWrapper = ({ active, id, children, editable }: Attribu
 	const [confirmModalOpen, confirmModalHandler] = useDisclosure(false)
 	const apiUtils = api.useUtils()
 	const toggleOrDeleteAttribute = api.component.AttributeEditWrapper.useMutation({
-		onSuccess: () => apiUtils.service.forServiceEditDrawer.invalidate(),
+		// `id` can belong to a phone/email/website row (when this wrapper is used from
+		// ContactInfo) or a service attribute (its original use in ServiceEditDrawer) --
+		// invalidate whichever router's cache actually holds the record that changed.
+		onSuccess: () => {
+			if (isIdFor('orgPhone', id)) {
+				return apiUtils.orgPhone.invalidate()
+			}
+			if (isIdFor('orgEmail', id)) {
+				return apiUtils.orgEmail.invalidate()
+			}
+			if (isIdFor('orgWebsite', id)) {
+				return apiUtils.orgWebsite.invalidate()
+			}
+			return apiUtils.service.forServiceEditDrawer.invalidate()
+		},
 	})
 	const handleToggle = useCallback(
 		() => toggleOrDeleteAttribute.mutate({ id, action: 'toggleActive' }),

--- a/packages/ui/components/data-portal/SocialMediaDrawer/index.tsx
+++ b/packages/ui/components/data-portal/SocialMediaDrawer/index.tsx
@@ -84,12 +84,12 @@ const _SocialMediaDrawer = forwardRef<HTMLButtonElement, SocialMediaDrawerProps>
 		const router = useRouter<'/org/[slug]/edit' | '/org/[slug]/[orgLocationId]/edit'>()
 		const { id: organizationId } = useOrgInfo()
 		const socialId = useMemo(() => (createNew ? generateId('orgSocialMedia') : id), [createNew, id])
-		const { data, isFetching } = api.orgSocialMedia.forEditDrawer.useQuery(
-			{ id: socialId },
-			{ enabled: !createNew }
-		)
 		const [drawerOpened, drawerHandler] = useDisclosure(false)
 		const [modalOpened, modalHandler] = useDisclosure(false)
+		const { data, isFetching } = api.orgSocialMedia.forEditDrawer.useQuery(
+			{ id: socialId },
+			{ enabled: drawerOpened && !createNew }
+		)
 		const { classes } = useStyles()
 		const {
 			control,
@@ -121,7 +121,17 @@ const _SocialMediaDrawer = forwardRef<HTMLButtonElement, SocialMediaDrawerProps>
 		const notifySave = useNewNotification({ displayText: 'Saved', icon: 'success' })
 		const databaseUpdate = api.orgSocialMedia.upsert.useMutation({
 			onSettled: () => {
-				apiUtils.orgSocialMedia.invalidate()
+				apiUtils.orgSocialMedia.forContactInfoEdits.invalidate()
+				apiUtils.orgSocialMedia.forContactInfo.invalidate()
+				// This drawer's own detail query is keyed by this specific social media id -
+				// without marking it stale too, reopening this same record later would show the
+				// pre-save data, making a second edit silently start from a stale field state
+				// instead of what was just saved. `refetchType: 'none'` marks it stale for next
+				// time without forcing an immediate refetch here - nothing is displaying this
+				// query while the drawer is closed, and forcing one batches it alongside the
+				// forContactInfoEdits refetch above in a way that ends up blocking that one from
+				// reaching the list.
+				apiUtils.orgSocialMedia.forEditDrawer.invalidate({ id: socialId }, { refetchType: 'none' })
 				reset()
 			},
 			onSuccess: () => {
@@ -134,7 +144,9 @@ const _SocialMediaDrawer = forwardRef<HTMLButtonElement, SocialMediaDrawerProps>
 		})
 		const hasLocationId = typeof router.query.orgLocationId === 'string' ? router.query.orgLocationId : null
 		const unlinkFromLocation = api.orgSocialMedia.locationLink.useMutation({
-			onSuccess: () => apiUtils.orgSocialMedia.invalidate(),
+			onSuccess: () => {
+				apiUtils.orgSocialMedia.forContactInfoEdits.invalidate()
+			},
 		})
 
 		const [urlValue] = useDebouncedValue(watch('url'), 300)

--- a/packages/ui/components/data-portal/WebsiteDrawer/index.tsx
+++ b/packages/ui/components/data-portal/WebsiteDrawer/index.tsx
@@ -46,18 +46,18 @@ const _WebsiteDrawer = forwardRef<HTMLButtonElement, WebsiteDrawerProps>(
 			return id
 		}, [createNew, id])
 
+		const [drawerOpened, drawerHandler] = useDisclosure(false)
+		const [modalOpened, modalHandler] = useDisclosure(false)
 		const { data: websiteData, isFetching } = api.orgWebsite.forEditDrawer.useQuery(
 			{ id: websiteId },
 			{
-				enabled: !createNew,
+				enabled: drawerOpened && !createNew,
 				// select: (returnedData) => ({
 				// 	...returnedData,
 				// 	...(createNew && hasLocationId && { orgLocationId: hasLocationId }),
 				// }),
 			}
 		)
-		const [drawerOpened, drawerHandler] = useDisclosure(false)
-		const [modalOpened, modalHandler] = useDisclosure(false)
 		const { classes } = useStyles()
 		const {
 			control,
@@ -95,7 +95,17 @@ const _WebsiteDrawer = forwardRef<HTMLButtonElement, WebsiteDrawerProps>(
 
 		const siteUpdate = api.orgWebsite.upsert.useMutation({
 			onSettled: () => {
-				apiUtils.orgWebsite.invalidate()
+				apiUtils.orgWebsite.forContactInfoEdit.invalidate()
+				apiUtils.orgWebsite.forContactInfo.invalidate()
+				// This drawer's own detail query is keyed by this specific website id - without
+				// marking it stale too, reopening this same website later would show the
+				// pre-save data, making a second edit silently start from a stale field state
+				// instead of what was just saved. `refetchType: 'none'` marks it stale for next
+				// time without forcing an immediate refetch here - nothing is displaying this
+				// query while the drawer is closed, and forcing one batches it alongside the
+				// forContactInfoEdit refetch above in a way that ends up blocking that one from
+				// reaching the list.
+				apiUtils.orgWebsite.forEditDrawer.invalidate({ id: websiteId }, { refetchType: 'none' })
 			},
 			onSuccess: () => {
 				setIsSaved(true)
@@ -107,7 +117,9 @@ const _WebsiteDrawer = forwardRef<HTMLButtonElement, WebsiteDrawerProps>(
 		})
 
 		const unlinkFromLocation = api.orgWebsite.locationLink.useMutation({
-			onSuccess: () => apiUtils.orgWebsite.invalidate(),
+			onSuccess: () => {
+				apiUtils.orgWebsite.forContactInfoEdit.invalidate()
+			},
 		})
 		useEffect(() => {
 			if (createNew && organizationId) {

--- a/packages/ui/components/sections/ListingBasicInfo.tsx
+++ b/packages/ui/components/sections/ListingBasicInfo.tsx
@@ -13,7 +13,7 @@ import { InlineTextInput } from '~ui/components/data-portal/InlineTextInput'
 import { useCustomVariant } from '~ui/hooks/useCustomVariant'
 import { useFormattedAddress } from '~ui/hooks/useFormattedAddress'
 import { useOrgInfo } from '~ui/hooks/useOrgInfo'
-import { BadgeEdit } from '~ui/modals/BadgeEdit'
+import { type BadgeAttributeRecord, BadgeEdit } from '~ui/modals/BadgeEdit'
 
 export const ListingBasicDisplay = memo(({ data }: ListingBasicInfoProps) => {
 	const { id: orgId } = useOrgInfo()
@@ -92,7 +92,7 @@ export const ListingBasicDisplay = memo(({ data }: ListingBasicInfoProps) => {
 })
 ListingBasicDisplay.displayName = 'ListingBasicDisplay'
 
-export const ListingBasicEdit = ({ data, location }: ListingBasicInfoProps) => {
+export const ListingBasicEdit = ({ data, location, onBadgesChange }: ListingBasicInfoProps) => {
 	const { id: orgId } = useOrgInfo()
 	const { t } = useTranslation(orgId)
 	const { formState } = useFormContext()
@@ -175,7 +175,12 @@ export const ListingBasicEdit = ({ data, location }: ListingBasicInfoProps) => {
 				<Group noWrap spacing={8}>
 					{!location && (
 						<>
-							<BadgeEdit orgId={orgIdFromData} badgeType='organization-leadership' component='a'>
+							<BadgeEdit
+								orgId={orgIdFromData}
+								badgeType='organization-leadership'
+								component='a'
+								onSaved={(newAttributes) => onBadgesChange?.('organization-leadership', newAttributes)}
+							>
 								<Badge.Group withSeparator>{leaderBadges()}</Badge.Group>
 							</BadgeEdit>
 							<Divider
@@ -196,7 +201,12 @@ export const ListingBasicEdit = ({ data, location }: ListingBasicInfoProps) => {
 							autosize
 							data-isdirty={formState.dirtyFields['description']}
 						/>
-						<BadgeEdit orgId={orgIdFromData} badgeType='service-focus' component='a'>
+						<BadgeEdit
+							orgId={orgIdFromData}
+							badgeType='service-focus'
+							component='a'
+							onSaved={(newAttributes) => onBadgesChange?.('service-focus', newAttributes)}
+						>
 							<Badge.Group>{focusedCommBadges}</Badge.Group>
 						</BadgeEdit>
 					</>
@@ -212,6 +222,16 @@ export const ListingBasicInfo = ({ edit, ...props }: ListingBasicInfoProps) =>
 export interface ListingBasicInfoProps extends OrgInfoProps {
 	edit?: boolean
 	location?: boolean
+	/**
+	 * Fires right after a leadership/service-focus badge selection is saved, with the full new selection in the
+	 * same shape as `data.attributes`. The org edit page uses this to patch its own `forOrgPageEdits` cache
+	 * directly, since `BadgeEdit` (in this shared UI package) runs on a separate tRPC client/QueryClient and
+	 * has no way to update the page's cache itself.
+	 */
+	onBadgesChange?: (
+		badgeType: 'organization-leadership' | 'service-focus',
+		newAttributes: BadgeAttributeRecord[]
+	) => void
 }
 
 export interface OrgInfoProps {
@@ -225,6 +245,7 @@ export interface OrgInfoProps {
 		attributes:
 			| NonNullable<ApiOutput['organization']['forOrgPage']>['attributes']
 			| NonNullable<ApiOutput['location']['forLocationPage']>['attributes']
+			| NonNullable<ApiOutput['organization']['forOrgPageEdits']>['attributes']
 		description:
 			| NonNullable<ApiOutput['organization']['forOrgPage']>['description']
 			| NonNullable<ApiOutput['location']['forLocationPage']>['description']

--- a/packages/ui/modals/BadgeEdit/index.tsx
+++ b/packages/ui/modals/BadgeEdit/index.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Box, createPolymorphicComponent, Modal, Stack, Title } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { compareArrayVals } from 'crud-object-diff'
+import compact from 'just-compact'
 import { useTranslation } from 'next-i18next'
 import { forwardRef } from 'react'
 import { useForm } from 'react-hook-form'
@@ -21,76 +22,140 @@ const FormSchema = z.object({
 	badges: z.string().array(),
 })
 type FormData = z.infer<typeof FormSchema>
-const _BadgeEditModal = forwardRef<HTMLButtonElement, Props>(({ orgId, badgeType, ...props }, ref) => {
-	const { classes } = useStyles()
-	const { t } = useTranslation()
-	const [opened, handler] = useDisclosure(false)
-	const { data: initialData } = api.organization.forBadgeEditModal.useQuery({ id: orgId, badgeType })
-	const form = useForm<FormData>({
-		resolver: zodResolver(FormSchema),
-		values: { id: orgId, badges: initialData ?? [] },
-	})
-	const { data: badgeOptions } = api.fieldOpt.orgBadges.useQuery({ badgeType })
 
-	const updateAttributes = api.organization.updateAttributesBasic.useMutation({
-		onSuccess: () => {
-			apiUtil.organization.invalidate()
-			form.reset()
-			handler.close()
-		},
-	})
+const _BadgeEditModal = forwardRef<HTMLButtonElement, Props>(
+	({ orgId, badgeType, onSaved, ...props }, ref) => {
+		const { classes } = useStyles()
+		const { t } = useTranslation()
+		const [opened, handler] = useDisclosure(false)
+		const { data: initialData } = api.organization.forBadgeEditModal.useQuery(
+			{ id: orgId, badgeType },
+			{ enabled: opened }
+		)
+		const form = useForm<FormData>({
+			resolver: zodResolver(FormSchema),
+			values: { id: orgId, badges: initialData ?? [] },
+		})
+		const { data: badgeOptions } = api.fieldOpt.orgBadges.useQuery({ badgeType }, { enabled: opened })
 
-	const apiUtil = api.useUtils()
+		const apiUtil = api.useUtils()
 
-	const handleSubmit = () => {
-		const data = form.getValues()
-		const changes = compareArrayVals([initialData ?? [], data.badges])
-		updateAttributes.mutate({ id: orgId, ...changes })
+		const updateAttributes = api.organization.updateAttributesBasic.useMutation({
+			onSuccess: (_result, variables) => {
+				// Write the known-correct new selection straight into the cache instead of
+				// relying on `invalidate()` -- the modal closes in this same callback, which
+				// disables this query (`enabled: opened`) and would cancel an in-flight
+				// refetch before it lands, leaving stale data for the next time it's opened.
+				const newBadges = [
+					...(initialData ?? []).filter((id) => !variables.deletedVals?.includes(id)),
+					...(variables.createdVals ?? []),
+				]
+				apiUtil.organization.forBadgeEditModal.setData({ id: orgId, badgeType }, newBadges)
+
+				// Let the parent page (which owns its own separate cache of the org's full attribute
+				// list) update its own display without a refetch. `badgeOptions` already has the full
+				// display metadata for every possible badge of this type, so we can build the same
+				// shape the page-level attribute list expects without an extra round trip.
+				const newAttributeRecords = compact(
+					newBadges.map((attributeId): BadgeAttributeRecord | undefined => {
+						const opt = badgeOptions?.find(({ id }) => id === attributeId)
+						if (!opt) {
+							return undefined
+						}
+						return {
+							id: opt.id,
+							attribute: {
+								id: opt.id,
+								tsKey: opt.tsKey,
+								tsNs: opt.tsNs,
+								icon: opt.icon,
+								iconBg: opt.iconBg,
+								categories: [{ category: { tag: badgeType } }],
+								_count: { parents: 0 },
+							},
+						}
+					})
+				)
+				onSaved?.(newAttributeRecords)
+
+				form.reset()
+				handler.close()
+			},
+		})
+
+		const handleSubmit = () => {
+			const data = form.getValues()
+			const changes = compareArrayVals([initialData ?? [], data.badges])
+			updateAttributes.mutate({ id: orgId, ...changes })
+		}
+
+		return (
+			<>
+				<Modal
+					title={<ModalTitle breadcrumb={{ option: 'close', onClick: handler.close }} />}
+					opened={opened}
+					onClose={handler.close}
+				>
+					<Stack spacing={20} align='center'>
+						<Title
+							order={2}
+						>{`Edit ${badgeType === 'organization-leadership' ? 'Organization Leadership' : 'Service Focus'} Badges`}</Title>
+						<Chip.Group multiple control={form.control} name='badges'>
+							<Stack spacing={12}>
+								{badgeOptions &&
+									badgeOptions.map(({ id, tsKey, tsNs, icon }) => (
+										<Chip.Item key={id} value={id}>
+											{`${icon} ${t(tsKey, { ns: tsNs })}`}
+										</Chip.Item>
+									))}
+							</Stack>
+						</Chip.Group>
+						<Button
+							variant='primary-icon'
+							type='submit'
+							fullWidth
+							onClick={handleSubmit}
+							disabled={!form.formState.isDirty}
+							leftIcon={<Icon icon={updateAttributes.isSuccess ? 'carbon:checkmark' : 'carbon:save'} />}
+							loading={updateAttributes.isLoading}
+						>
+							{t('save-changes')}
+						</Button>
+					</Stack>
+				</Modal>
+				<Box ref={ref} component='button' onClick={handler.open} className={classes.overlay} {...props} />
+			</>
+		)
 	}
-
-	return (
-		<>
-			<Modal
-				title={<ModalTitle breadcrumb={{ option: 'close', onClick: handler.close }} />}
-				opened={opened}
-				onClose={handler.close}
-			>
-				<Stack spacing={20} align='center'>
-					<Title
-						order={2}
-					>{`Edit ${badgeType === 'organization-leadership' ? 'Organization Leadership' : 'Service Focus'} Badges`}</Title>
-					<Chip.Group multiple control={form.control} name='badges'>
-						<Stack spacing={12}>
-							{badgeOptions &&
-								badgeOptions.map(({ id, tsKey, tsNs, icon }) => (
-									<Chip.Item key={id} value={id}>
-										{`${icon} ${t(tsKey, { ns: tsNs })}`}
-									</Chip.Item>
-								))}
-						</Stack>
-					</Chip.Group>
-					<Button
-						variant='primary-icon'
-						type='submit'
-						fullWidth
-						onClick={handleSubmit}
-						disabled={!form.formState.isDirty}
-						leftIcon={<Icon icon={updateAttributes.isSuccess ? 'carbon:checkmark' : 'carbon:save'} />}
-						loading={updateAttributes.isLoading}
-					>
-						{t('save-changes')}
-					</Button>
-				</Stack>
-			</Modal>
-			<Box ref={ref} component='button' onClick={handler.open} className={classes.overlay} {...props} />
-		</>
-	)
-})
+)
 _BadgeEditModal.displayName = 'BadgeEditModal'
 
 export const BadgeEdit = createPolymorphicComponent<'button', Props>(_BadgeEditModal)
 
+/**
+ * Matches the shape of an entry in `ApiOutput['organization']['forOrgPageEdits']['attributes']` - kept
+ * minimal/local rather than imported so this modal doesn't need to know about that query.
+ */
+export interface BadgeAttributeRecord {
+	id: string
+	attribute: {
+		id: string
+		tsKey: string
+		tsNs: string
+		icon: string | null
+		iconBg: string | null
+		categories: Array<{ category: { tag: string } }>
+		_count: { parents: number }
+	}
+}
+
 interface Props {
 	orgId: string
 	badgeType: ApiInput['fieldOpt']['orgBadges']['badgeType']
+	/**
+	 * Called with the full, freshly-saved badge selection (in the same shape the org edit page's own attribute
+	 * list uses) right after a successful save - lets a parent that has its own separate cache of that list (a
+	 * different tRPC client/QueryClient than this modal uses) patch its own display without a page reload.
+	 */
+	onSaved?: (newAttributes: BadgeAttributeRecord[]) => void
 }


### PR DESCRIPTION
## Summary

A series of performance and correctness fixes to the org edit page (`/org/[slug]/edit`) and its contact-info drawers, found through iterative manual testing against a live preview of the untouched `dev` branch.

### Performance
- Rewrote the audit-trail lookup powering "First published"/"Last updated" to use an indexed query instead of an unindexed JSONB scan (~522ms → ~7.6ms).
- Gated contact-info drawers and the badge modal so their detail queries only fire when opened, not on page load.
- Removed a redundant reverse-lookup query in the phone edit drawer.
- Added `syncDatabaseStringIfChanged` (`packages/crowdin/api`) so saves only round-trip to Crowdin when the description text actually changed, and skip the extra lookup call when a `crowdinId` is already known — applied across phone/email/website/org/service handlers.

### Correctness
- Fixed the eye/trash toggle on contact rows invalidating the wrong router for phone/email/website records (`AttributeEditWrapper.tsx`).
- Fixed the badge modal showing stale data on reopen, and the org page not reflecting a saved badge change without a full reload (separate query keys that didn't auto-sync).
- Fixed the address autocomplete dropping the street field when only some parts of an address were available, dropping the street number when a suggestion was selected (a redundant search re-triggered by the selection itself), and dropping it again for addresses Google's geocode API can't resolve to an exact street number.
- Added real phone number validation (previously any string saved silently, including malformed numbers) and made the masked input format numbers correctly for whichever country is actually selected, not just the default.
- Added a fallback display for phone numbers already saved in a format the masked input can't parse, so they're visible and fixable instead of rendering blank.
- Fixed contact-info drawers never invalidating their own detail query, so reopening a just-saved record could show pre-save data.
- Fixed a race where the phone list could receive two responses for the same refetch out of order, letting stale data silently overwrite a just-saved change — replaced with a direct cache write instead of relying on invalidate-then-refetch timing.

## Known follow-ups (not in this PR)
- `orgWebsite.upsert`'s create path mints ids with the wrong table prefix (`oeml_` instead of `oweb_`) — filed separately.
- `orgSocialMedia` has no Crowdin sync, unlike every other contact type — filed separately.
- `LocationCard`'s edit-page summary doesn't forward edit mode to address-visibility redaction (no live symptom today) — filed separately.
- The phone list's cache patch doesn't reflect a phone-*type* dropdown change immediately (self-corrects on next page load).
- Email/Website/SocialMedia drawers likely share the same list-race the phone drawer had; not yet applied pending confirmation the phone fix holds up.

## Test plan
- [ ] Load the edit page — confirm dates are correct and drawer/badge queries don't fire until opened.
- [ ] Badge modal: change selection, save — page updates without reload; reopen shows the saved selection.
- [ ] Phone/email/website/social: toggle published, save, toggle again, save — list updates correctly both times; reopening a saved record shows what was just saved.
- [ ] Phone: enter a malformed number — save is blocked with a clear error; a number already malformed in the DB shows as raw text (not blank) when reopened.
- [ ] Address autocomplete: partial address parts, Enter/Tab after selecting a suggestion, and a geocode-imprecise address all retain the street number.
- [ ] Create a new location — appears without a full page reload.