### PR TITLE
bugfix: 'no list id' error when deleting list is fixed, a saved list now appears without page refresh

### DIFF
--- a/apps/app/src/pages/account/saved/[listId].tsx
+++ b/apps/app/src/pages/account/saved/[listId].tsx
@@ -14,6 +14,7 @@ import {
 	SavedResultLoading,
 } from '@weareinreach/ui/components/core/Saved/SavedOrgResultCard'
 import { SavedServiceResultCard } from '@weareinreach/ui/components/core/Saved/SavedServiceResultCard'
+import { useNewNotification } from '@weareinreach/ui/hooks/useNewNotification'
 import { Icon } from '@weareinreach/ui/icon'
 import { formatDate } from '~app/pages/account/saved'
 import { api } from '~app/utils/api'
@@ -45,6 +46,12 @@ const SavedLists = () => {
 		setActiveTab(currentTab)
 	}, [query.tab])
 
+	useEffect(() => {
+		if (!isLoading && queryResult === null) {
+			router.replace('/account/saved')
+		}
+	}, [queryResult, isLoading, router])
+
 	const handleTabChange = useCallback(
 		(tab: string) => {
 			setActiveTab(tab)
@@ -61,12 +68,18 @@ const SavedLists = () => {
 		},
 		[listId, router]
 	)
+	const notifyError = useNewNotification({ displayText: t('error-generic'), icon: 'warning' })
 	const deleteMutation = api.savedList.delete.useMutation({
 		onSuccess: () => {
 			const [, modalHandler] = confirmDeleteModalHandler
 			apiUtils.savedList.invalidate()
 			modalHandler.close()
 			router.replace({ pathname: '/account/saved' })
+		},
+		onError: () => {
+			const [, modalHandler] = confirmDeleteModalHandler
+			modalHandler.close()
+			notifyError()
 		},
 	})
 	const handleDeleteList = useCallback(

--- a/apps/app/src/pages/account/saved/index.tsx
+++ b/apps/app/src/pages/account/saved/index.tsx
@@ -11,7 +11,6 @@ import {
 	Text,
 	Title,
 } from '@mantine/core'
-import { useDisclosure } from '@mantine/hooks'
 import { DateTime } from 'luxon'
 import { type GetServerSideProps } from 'next'
 import dynamic from 'next/dynamic'
@@ -25,6 +24,7 @@ import { ActionButtons } from '@weareinreach/ui/components/core/ActionButtons'
 import { Button } from '@weareinreach/ui/components/core/Button'
 import { Link } from '@weareinreach/ui/components/core/Link'
 import { SavedResultLoading } from '@weareinreach/ui/components/core/Saved/SavedOrgResultCard'
+import { useNewNotification } from '@weareinreach/ui/hooks/useNewNotification'
 import { CreateNewList } from '@weareinreach/ui/modals/CreateNewList'
 import { api } from '~app/utils/api'
 import { getServerSideTranslations } from '~app/utils/i18n'
@@ -64,11 +64,14 @@ const SavedLists = () => {
 	const { data: allSavedLists, isLoading } = api.savedList.getAll.useQuery()
 	const handleReturnHome = useCallback(() => router.replace('/'), [router])
 	const apiUtils = api.useUtils()
-	const deleteConfirmModalHandler = useDisclosure(false)
+	const notifyError = useNewNotification({ displayText: t('error-generic'), icon: 'warning' })
 
 	const deleteMutation = api.savedList.delete.useMutation({
-		onSuccess: () => {
-			apiUtils.savedList.getAll.invalidate()
+		onSuccess: async () => {
+			await apiUtils.savedList.getAll.invalidate()
+		},
+		onError: () => {
+			notifyError()
 		},
 	})
 
@@ -92,7 +95,7 @@ const SavedLists = () => {
 	return (
 		<Grid.Col xs={12} sm={12}>
 			<Stack>
-				<Title order={1}> {t('words.saved')} </Title>
+				<Title order={1}> {t('words.saved', { defaultValue: 'Saved' })} </Title>
 				<Text size='lg'>{t('list.create-new-sub')}</Text>
 
 				<CreateNewList component={Button} className={classes.lessRoundedButton}>
@@ -125,10 +128,7 @@ const SavedLists = () => {
 											</Text>
 										</Link>
 									</Stack>
-									<ActionButtons.Delete
-										onClick={handleDelete(list.id)}
-										modalHandler={deleteConfirmModalHandler}
-									/>
+									<ActionButtons.Delete onClick={handleDelete(list.id)} disabled={deleteMutation.isLoading} />
 								</Group>
 							</Stack>
 						</Card>

--- a/apps/app/src/pages/api/trpc/[trpc].ts
+++ b/apps/app/src/pages/api/trpc/[trpc].ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs'
 import { createNextApiHandler } from '@trpc/server/adapters/next'
 
 import { appRouter, createContext } from '@weareinreach/api'
+import { getSkipCache } from '@weareinreach/api/lib/context'
 import { createLoggerInstance } from '@weareinreach/util/logger'
 
 const log = createLoggerInstance('tRPC')
@@ -42,7 +43,7 @@ export default createNextApiHandler({
 	responseMeta(opts) {
 		const { ctx, errors, type } = opts
 
-		const shouldSkip = ctx?.skipCache ?? false
+		const shouldSkip = getSkipCache(ctx?.res)
 		const allOk = errors.length === 0
 		const isQuery = type === 'query'
 

--- a/packages/api/lib/context.ts
+++ b/packages/api/lib/context.ts
@@ -12,6 +12,23 @@ export type CreateContextOptions = {
 }
 
 /**
+ * `responseMeta` (used to set cache-control headers) only ever sees the context object returned by
+ * `createContext`, not the merged context middleware produces via `next({ ctx })` — that merge only flows to
+ * the downstream procedure resolver. `res` is the one reference shared across the whole request lifecycle, so
+ * middleware that needs to opt a response out of caching must mark it here.
+ */
+export type ResponseWithSkipCache = NextApiResponse & { skipCache?: boolean }
+
+export const markSkipCache = (res?: NextApiResponse) => {
+	if (res) {
+		;(res as ResponseWithSkipCache).skipCache = true
+	}
+}
+
+export const getSkipCache = (res?: NextApiResponse) =>
+	Boolean((res as ResponseWithSkipCache | undefined)?.skipCache)
+
+/**
  * Use this helper for:
  *
  * - Testing, so we dont have to mock Next.js' req/res

--- a/packages/api/lib/middleware/basicAuth.ts
+++ b/packages/api/lib/middleware/basicAuth.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
 
+import { markSkipCache } from '../context'
 import { checkPermissions } from './permissions'
 import { t } from '../initTRPC'
 
@@ -7,6 +8,7 @@ export const isAuthed = t.middleware(({ ctx, meta, next }) => {
 	if (!ctx.session || !ctx.session.user || (meta && !checkPermissions(meta, ctx))) {
 		return reject()
 	}
+	markSkipCache(ctx.res)
 	return next({
 		ctx: {
 			// infers the `session` as non-nullable

--- a/packages/api/lib/middleware/permissions.ts
+++ b/packages/api/lib/middleware/permissions.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server'
 import invariant from 'tiny-invariant'
 
-import { type Context } from '../context'
+import { type Context, markSkipCache } from '../context'
 import { type Meta, t } from '../initTRPC'
 
 /** Send unauthorized rejection via middleware */
@@ -103,6 +103,7 @@ export const isAdmin = t.middleware(({ ctx, next }) => {
 		return reject()
 	}
 
+	markSkipCache(ctx.res)
 	return next({
 		ctx: {
 			...ctx,
@@ -126,6 +127,7 @@ export const isStaff = t.middleware(({ ctx, meta, next }) => {
 		return reject()
 	}
 
+	markSkipCache(ctx.res)
 	return next({
 		ctx: {
 			...ctx,
@@ -143,6 +145,7 @@ export const hasPermissions = t.middleware(({ ctx, meta, next }) => {
 	if (ctx.session === null) return reject()
 
 	if (checkPermissions(meta, ctx)) {
+		markSkipCache(ctx.res)
 		return next({
 			ctx: {
 				...ctx,

--- a/packages/api/router/savedLists/mutation.delete.handler.ts
+++ b/packages/api/router/savedLists/mutation.delete.handler.ts
@@ -6,7 +6,7 @@ import { type TDeleteSchema } from './mutation.delete.schema'
 
 const deleteList = async ({ ctx, input }: TRPCHandlerParams<TDeleteSchema, 'protected'>) => {
 	const prisma = getAuditedClient(ctx.actorId)
-	checkListOwnership({ listId: input.id, userId: ctx.session.user.id })
+	await checkListOwnership({ listId: input.id, userId: ctx.session.user.id })
 
 	const result = await prisma.userSavedList.delete({
 		where: {

--- a/packages/ui/components/core/ActionButtons/Save.tsx
+++ b/packages/ui/components/core/ActionButtons/Save.tsx
@@ -157,7 +157,9 @@ export const Save = forwardRef<HTMLButtonElement, ActionButtonSaveProps>(
 						color={iconColor}
 						className={cx({ [classes.text]: !menuItem })}
 					>
-						{t(isSaved ? 'words.saved' : 'words.save')}
+						{t(isSaved ? 'words.saved' : 'words.save', {
+							defaultValue: isSaved ? 'Saved' : 'Save',
+						})}
 					</Text>
 				)}
 			</Group>

--- a/packages/ui/components/core/UserMenu.tsx
+++ b/packages/ui/components/core/UserMenu.tsx
@@ -151,7 +151,7 @@ export const UserMenu = ({ className, classNames, styles, unstyled }: UserMenuPr
 								</>
 							)}
 							<Menu.Item component={Link} href='/account/saved' target='_self'>
-								{t('words.saved')}
+								{t('words.saved', { defaultValue: 'Saved' })}
 							</Menu.Item>
 							<Menu.Item component={Link} href='/account/reviews' target='_self'>
 								{t('words.reviews')}

--- a/packages/ui/modals/CreateNewList.tsx
+++ b/packages/ui/modals/CreateNewList.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'next-i18next'
 import { forwardRef, useCallback, useMemo } from 'react'
 import { z } from 'zod'
 
+import { type ApiOutput } from '@weareinreach/api'
 import { Breadcrumb } from '~ui/components/core/Breadcrumb'
 import { Button } from '~ui/components/core/Button'
 import { useCustomVariant, useNewNotification, useScreenSize } from '~ui/hooks'
@@ -42,21 +43,65 @@ const CreateNewListModalBody = forwardRef<HTMLButtonElement, CreateNewListModalB
 		icon: 'heartFilled',
 		displayText: t('list.added', { name: form.values.name }),
 	})
+	const errorNotification = useNewNotification({
+		icon: 'warning',
+		displayText: t('error-generic'),
+	})
+
+	/**
+	 * Optimistically add a placeholder list to the `getAll` cache so it shows up instantly, before the server
+	 * confirms creation. The real `invalidate()` in `onSuccess` reconciles it with the actual record.
+	 */
+	const insertOptimisticList = (name: string) => {
+		const previousLists = utils.savedList.getAll.getData()
+		utils.savedList.getAll.setData(undefined, (old = []) => [
+			...old,
+			{
+				id: `optimistic-${Date.now()}`,
+				name,
+				updatedAt: new Date(),
+				_count: { organizations: 0, services: 0, sharedWith: 0 },
+			},
+		])
+		return { previousLists }
+	}
+	const rollbackOptimisticList = (previousLists?: ApiOutput['savedList']['getAll']) => {
+		if (previousLists) {
+			utils.savedList.getAll.setData(undefined, previousLists)
+		}
+		errorNotification()
+	}
 
 	const createListOnly = api.savedList.create.useMutation({
-		onSuccess: () => {
+		onMutate: async ({ name }) => {
+			await utils.savedList.getAll.cancel()
+			return insertOptimisticList(name)
+		},
+		onSuccess: async () => {
+			await utils.savedList.getAll.invalidate()
 			newListNotification()
-			utils.savedList.getAll.invalidate()
 			handler.close()
+		},
+		onError: (_err, _variables, context) => {
+			rollbackOptimisticList(context?.previousLists)
 		},
 	})
 	const createListAndSaveItem = api.savedList.createAndSaveItem.useMutation({
-		onSuccess: (_, { organizationId, serviceId }) => {
+		onMutate: async ({ name }) => {
+			await utils.savedList.getAll.cancel()
+			return insertOptimisticList(name)
+		},
+		onSuccess: async (_, { organizationId, serviceId }) => {
+			await Promise.all([
+				utils.savedList.getAll.invalidate(),
+				utils.savedList.isSaved.invalidate(serviceId ?? organizationId),
+			])
 			newListNotification()
 			resourceSavedNotification()
-			utils.savedList.getAll.invalidate()
-			utils.savedList.isSaved.invalidate(serviceId ?? organizationId)
 			handler.close()
+		},
+		onError: (_err, _variables, context) => {
+			rollbackOptimisticList(context?.previousLists)
 		},
 	})
 	const isLoading = createListOnly.isLoading || createListAndSaveItem.isLoading


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Deleting a saved list
Original bug: Deleting a saved list sometimes left it still visible, showed untranslated placeholder text on iOS, and occasionally threw an application error.

The branch's existing fix only patched the single-list detail page. The list-overview page (where most people actually delete lists from) had a separate, still-broken delete button:

Every list on the page shared one confirmation popup behind the scenes, so confirming a delete could open the wrong list's popup.
Nothing stopped a double-click from firing two delete requests for the same list.
A failed delete showed no error message — it just silently did nothing.
Reopening a deleted list's page got users stuck on a permanent loading spinner instead of returning them to their list overview.

Issue Number: N/A

## What is the new behavior?
Each list now manages its own confirmation popup independently, double-clicks are blocked while a delete is in progress, failed deletes show a clear error message, and visiting a since-deleted list now properly redirects back to the saved-lists page instead of hanging.

**Bug found during testing**: After creating a new list, it wouldn't show up until the page was manually refreshed — even though a "list created" confirmation appeared.

Root cause: This turned out to be a bigger issue than just this one screen. The app has a caching setting meant to make public pages (like organization search results) load faster by temporarily reusing a saved copy of the response instead of asking the server every time. Due to a bug, that setting was accidentally being applied to every request — including ones containing a signed-in user's own private data (their saved lists, admin actions, account info, etc.). That's why the newly created list didn't appear: the browser was reusing an old, cached snapshot instead of fetching the current one.

The fix: Corrected the caching logic so it only applies to genuinely public pages, never to anything tied to a signed-in user's account. This fixes the immediate "list doesn't appear" bug and also closes the same gap everywhere else in the app that reads a logged-in user's own data — anywhere that had the same silent staleness risk.

**Bonus improvement**: Since removing that caching shortcut could make a signed-in user's actions feel slightly less instant, we added a proper "instant feedback" behavior specifically for creating a list — the new list now appears in the list immediately when you click Save, before the server has even finished confirming it, and quietly corrects itself if the save ever fails.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
