### PR TITLE
bugfix: give proper error if saving an email fails

### DIFF
--- a/packages/ui/modals/dataPortal/Attributes/index.tsx
+++ b/packages/ui/modals/dataPortal/Attributes/index.tsx
@@ -70,6 +70,20 @@ const getDynamicSchema = (t: TFunction, dataSchemaName?: string, attributeKey?: 
 					z.undefined(),
 				])
 			}
+		} else if (dataSchemaName === 'access-instruction-email') {
+			// Trim whitespace before validating so a pasted address with incidental leading/trailing
+			// spaces doesn't fail format validation, and use the same error copy as other email fields.
+			dataSchema = z
+				.object({
+					access_type: z.literal('email').default('email'),
+					access_value: z
+						.string()
+						.trim()
+						.email({ message: t('form-error-enter-valid-email', { ns: 'common' }) })
+						.nullish(),
+					instructions: z.string().optional(),
+				})
+				.strict()
 		}
 		const dynamicSchema = formSchema.extend({ data: dataSchema })
 		return dynamicSchema
@@ -186,6 +200,7 @@ const AttributeForm = ({ parentRecord, selectedAttr, onSave, isLoading }: Attrib
 					})}
 					type='submit'
 					loading={isLoading}
+					disabled={!form.formState.isValid}
 				>
 					{t('words.save', { ns: 'common' })}
 				</Button>
@@ -238,6 +253,10 @@ const AttributeModalBody = forwardRef<HTMLButtonElement, AttributeModalProps>(
 		useTranslation(['attribute', 'common'])
 		const [opened, handler] = useDisclosure(false)
 		const showAddedNotification = useNewNotification({ icon: 'added', displayText: 'Added Attribute' })
+		const showErrorNotification = useNewNotification({
+			icon: 'warning',
+			displayText: 'Error Saving Attribute',
+		})
 		const apiUtils = api.useUtils()
 		const [attrCat, setAttrCat] = useState<string | null>()
 		const [showInactiveAttribs, setShowInactiveAttribs] = useState(true)
@@ -255,6 +274,7 @@ const AttributeModalBody = forwardRef<HTMLButtonElement, AttributeModalProps>(
 				showAddedNotification()
 				handler.close()
 			},
+			onError: showErrorNotification,
 		})
 
 		// #region Handlers


### PR DESCRIPTION
Fix intermittent silent failure when adding an Email Service Access Instruction

# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

When adding a Service Access Instruction of type "Email" via Add Attribute → Service Access Instructions → Email, the client-side Zod schema validates the address with a strict `.email()` check, but nothing trims the value first. An address with incidental leading/trailing whitespace (very common when pasted from an email signature, PDF, spreadsheet, or business card) fails that check.

Because the Save button's `form.handleSubmit` silently no-ops when validation fails, no network request is ever sent, the modal gives no visible feedback (no toast, no console error, the button doesn't even flash a loading state), and the email never appears on the service drawer. This reproduces "very occasionally" since most emails are typed/pasted cleanly, and it presents identically to a previously reported "add access instruction" bug even though the mechanism is different — a silent client-side validation gate, not a save/server issue.

## What is the new behavior?

- Email access-instruction values are now trimmed before format validation, so addresses with incidental leading/trailing whitespace save correctly instead of silently failing.
- The invalid-email error message now matches the copy already used elsewhere in the app (`"Please enter a valid email address."`) instead of Zod's generic default message.
- The Save button is now disabled while the form is invalid, so a genuinely malformed email visibly blocks saving instead of the button silently doing nothing.
- Added an `onError` handler on the save mutation with a warning toast, matching the app's existing error-notification pattern, so a server-side failure is no longer silent either.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Root cause was confirmed by running the actual validation schema against sample inputs (e.g. `"user@example.com "` failed before the fix, passes and is stored trimmed after). Truly malformed emails (e.g. `"not-an-email"`) still correctly fail validation. Verified via `tsc --noEmit` and `eslint` on the changed file — both clean.

Changed file: `packages/ui/modals/dataPortal/Attributes/index.tsx`

## Non-Technical Summary

- Staff adding an email as a "how to access this service" instruction would occasionally have it silently fail to save — usually caused by an invisible extra space copied in along with the email address.
- The save button now clearly shows when an email isn't valid instead of quietly doing nothing, and staff will now see an error message if a save ever fails for another reason.
- Emails with a stray extra space (common when copy-pasting) will now save correctly instead of failing.
