### PR TITLE
fix: Storybook next-i18next alias breaks /pages subpath imports

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -103,7 +103,14 @@ const storybookConfig: StorybookConfig = {
 						__dirname,
 						'mockAuthStates.ts'
 					),
-					'next-i18next': 'react-i18next',
+					// Storybook has no real Next.js server context, so next-i18next's Pages Router
+					// build (which the rest of the app imports as `next-i18next/pages` since the
+					// v16 upgrade) isn't usable here - alias straight to react-i18next instead.
+					// Must be the full `/pages` path, not bare `next-i18next`: without a trailing
+					// `$`, webpack's alias is a prefix match, so a bare-key alias here would also
+					// rewrite `next-i18next/pages` -> `react-i18next/pages`, a subpath that
+					// doesn't exist on react-i18next.
+					'next-i18next/pages': 'react-i18next',
 					'msw/native': path.resolve(__dirname, '../node_modules/msw/lib/native/index.mjs'),
 				},
 				roots: [publicStatic],


### PR DESCRIPTION
# Pull Request type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

Every Storybook build fails: `packages/ui/.storybook/main.ts` has a webpack alias
`'next-i18next': 'react-i18next'` that predates the next-i18next v16 migration (which moved all
imports from bare `next-i18next` to `next-i18next/pages`, done earlier this cycle). Without a
trailing `$`, webpack's `resolve.alias` is a prefix match, so this alias also rewrites
`next-i18next/pages` -> `react-i18next/pages` - a subpath that doesn't exist on `react-i18next`,
crashing the build with `Module not found: "./pages" is not exported`.

This was undetected until now because Chromatic (the only thing that runs `sb:build` in CI) has
been `disabled_manually` with zero runs, ever - discovered while re-enabling it as prep work for
the upcoming React/Next/Mantine migration.

## What is the new behavior?

- Alias key changed from `'next-i18next'` to `'next-i18next/pages'`, matching the actual import
  path used everywhere in the codebase since the v16 migration.
- Verified locally: `pnpm sb:build` completes successfully (previously failed on this exact error).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Single-line fix, one file. Blocks capturing a Chromatic visual-regression baseline before the
upcoming Mantine migration starts, so worth merging quickly.

## Non-Technical Summary

- Fixes a broken build tool (Storybook, our component-preview/testing tool) that's been silently
  failing - no user-facing change.